### PR TITLE
Remove json profile references

### DIFF
--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -18,11 +18,11 @@ Configuration
 interpreter = Interpreter()
 
 # Load from custom profile
-config = Config.from_file("~/custom_profile.json")
+config = Config.from_file("~/custom_profile.py")
 interpreter = Interpreter(config)
 
 # Save current settings
-interpreter.save_config("~/my_settings.json")
+interpreter.save_config("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -12,7 +12,7 @@ Basic Usage
 
 Configuration
 ------------
->>> from interpreter import Interpreter, Config
+>>> from interpreter import Interpreter, Profile
 
 Use defaults:
 
@@ -20,12 +20,12 @@ Use defaults:
 
 Load from custom profile:
 
->>> config = Config.from_file("~/custom_profile.py")
->>> interpreter = Interpreter(config)
+>>> profile = Profile.from_file("~/custom_profile.py")
+>>> interpreter = Interpreter(profile)
 
 Save current settings:
 
->>> interpreter.save_config("~/my_settings.py")
+>>> interpreter.save_profile("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -14,15 +14,18 @@ Configuration
 ------------
 >>> from interpreter import Interpreter, Config
 
-# Use defaults
-interpreter = Interpreter()
+Use defaults:
 
-# Load from custom profile
-config = Config.from_file("~/custom_profile.py")
-interpreter = Interpreter(config)
+>>> interpreter = Interpreter()
 
-# Save current settings
-interpreter.save_config("~/my_settings.py")
+Load from custom profile:
+
+>>> config = Config.from_file("~/custom_profile.py")
+>>> interpreter = Interpreter(config)
+
+Save current settings:
+
+>>> interpreter.save_config("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -93,17 +93,20 @@ class Interpreter:
     --------
     >>> from interpreter import Interpreter
 
-    # Basic usage
-    interpreter = Interpreter()
-    interpreter.chat()
+    Basic usage:
 
-    # With custom configuration
-    from interpreter import Profile
-    profile = Profile.from_file("~/custom_profile.py")
-    interpreter = Interpreter(profile)
+    >>> interpreter = Interpreter()
+    >>> interpreter.chat()
 
-    # Save settings for later
-    interpreter.save_profile("~/my_settings.py")
+    With custom configuration:
+
+    >>> from interpreter import Profile
+    >>> profile = Profile.from_file("~/custom_profile.py")
+    >>> interpreter = Interpreter(profile)
+
+    Save settings for later:
+
+    >>> interpreter.save_profile("~/my_settings.py")
 
     Parameters
     ----------

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -99,11 +99,11 @@ class Interpreter:
 
     # With custom configuration
     from interpreter import Profile
-    profile = Profile.from_file("~/custom_profile.json")
+    profile = Profile.from_file("~/custom_profile.py")
     interpreter = Interpreter(profile)
 
     # Save settings for later
-    interpreter.save_profile("~/my_settings.json")
+    interpreter.save_profile("~/my_settings.py")
 
     Parameters
     ----------
@@ -152,7 +152,7 @@ class Interpreter:
         Load settings from a profile file
 
         Example:
-        >>> interpreter.load_profile("~/work_settings.json")
+        >>> interpreter.load_profile("~/work_settings.py")
         """
         self._profile.load(path)
         # Update interpreter attributes from new profile
@@ -164,7 +164,7 @@ class Interpreter:
         Save current settings as a profile
 
         Example:
-        >>> interpreter.save_profile("~/my_preferred_settings.json")
+        >>> interpreter.save_profile("~/my_preferred_settings.py")
         """
         # Update profile object with current values
         self._profile.from_dict(self.to_dict())
@@ -177,7 +177,7 @@ class Interpreter:
         Create new interpreter instance from a profile file
 
         Example:
-        >>> interpreter = Interpreter.from_profile("~/work_settings.json")
+        >>> interpreter = Interpreter.from_profile("~/work_settings.py")
         """
         return cls(Profile.from_file(path))
 

--- a/interpreter/misc/welcome.py
+++ b/interpreter/misc/welcome.py
@@ -254,9 +254,9 @@ Execute natural language commands on your computer
     --serve               Start in server mode
 
 example: interpreter "create a python script"
-example: interpreter -m gpt-4 "analyze data.csv" 
+example: interpreter -m gpt-4 "analyze data.csv"
 example: interpreter --auto-run "install nodejs"
-example: interpreter --profile work.json
+example: interpreter --profile work.py
 """
     )
 
@@ -282,9 +282,9 @@ Execute natural language commands on your computer
     --serve               Start in server mode
 
 example: interpreter "create a python script"
-example: interpreter -m gpt-4 "analyze data.csv" 
+example: interpreter -m gpt-4 "analyze data.csv"
 example: interpreter --auto-run "install nodejs"
-example: interpreter --profile work.json
+example: interpreter --profile work.py
 """
     )
 

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -16,14 +16,17 @@ class Profile:
     --------
     >>> from interpreter import Profile
 
-    # Load defaults (and ~/.openinterpreter if it exists)
-    profile = Profile()
+    Load defaults (and ~/.openinterpreter if it exists):
 
-    # Load from specific profile
-    profile = Profile.from_file("~/custom_profile.py")
+    >>> profile = Profile()
 
-    # Save current settings
-    profile.save("~/my_settings.py")
+    Load from specific profile:
+
+    >>> profile = Profile.from_file("~/custom_profile.py")
+
+    Save current settings:
+
+    >>> profile.save("~/my_settings.py")
     """
 
     DEFAULT_PROFILE_FOLDER = "~/.openinterpreter"

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -20,10 +20,10 @@ class Profile:
     profile = Profile()
 
     # Load from specific profile
-    profile = Profile.from_file("~/custom_profile.json")
+    profile = Profile.from_file("~/custom_profile.py")
 
     # Save current settings
-    profile.save("~/my_settings.json")
+    profile.save("~/my_settings.py")
     """
 
     DEFAULT_PROFILE_FOLDER = "~/.openinterpreter"

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -132,7 +132,8 @@ class Profile:
             path += ".py"
 
         if not os.path.exists(path):
-            # If file doesn't exist, if it's the default, that's fine
+            # If the missing file is the default profile path, that's fine -
+            # we'll use the defaults from __init__
             if os.path.abspath(os.path.expanduser(path)) == os.path.abspath(
                 os.path.expanduser(self.DEFAULT_PROFILE_PATH)
             ):

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -1,8 +1,5 @@
-import json
 import os
-import platform
 import sys
-from datetime import datetime
 
 
 class Profile:

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -147,7 +147,9 @@ class Profile:
                 # This avoids loading the full interpreter module which is resource intensive
                 content = content.replace(
                     "from interpreter import interpreter",
-                    "class Interpreter:\n    pass\ninterpreter = Interpreter()",
+                    "class Interpreter:\n"
+                    "    pass\n"
+                    "interpreter = Interpreter()",
                 )
 
                 # Execute the modified profile content


### PR DESCRIPTION
### Describe the changes you have made:

- Replace .json profile references with .py: Profiles were changed from .json to .py files in bee3f3c3, but the documentation was not updated everywhere.
- Fix doctest examples format
- Update reference to "Config" which doesn't exist: Possibly related to 4e97cd77
- Clarify comment about default profile: There is no file called `default_profile.py`.  I'm not sure why we would imply that it exists, and allow it to be used, but just clarify the comment for now.


### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
