### PR TITLE
Prevent profile file from being overridden by defaults

### DIFF
--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -18,11 +18,11 @@ Configuration
 interpreter = Interpreter()
 
 # Load from custom profile
-config = Config.from_file("~/custom_profile.json")
+config = Config.from_file("~/custom_profile.py")
 interpreter = Interpreter(config)
 
 # Save current settings
-interpreter.save_config("~/my_settings.json")
+interpreter.save_config("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -12,7 +12,7 @@ Basic Usage
 
 Configuration
 ------------
->>> from interpreter import Interpreter, Config
+>>> from interpreter import Interpreter, Profile
 
 Use defaults:
 
@@ -20,12 +20,12 @@ Use defaults:
 
 Load from custom profile:
 
->>> config = Config.from_file("~/custom_profile.py")
->>> interpreter = Interpreter(config)
+>>> profile = Profile.from_file("~/custom_profile.py")
+>>> interpreter = Interpreter(profile)
 
 Save current settings:
 
->>> interpreter.save_config("~/my_settings.py")
+>>> interpreter.save_profile("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/__init__.py
+++ b/interpreter/__init__.py
@@ -14,15 +14,18 @@ Configuration
 ------------
 >>> from interpreter import Interpreter, Config
 
-# Use defaults
-interpreter = Interpreter()
+Use defaults:
 
-# Load from custom profile
-config = Config.from_file("~/custom_profile.py")
-interpreter = Interpreter(config)
+>>> interpreter = Interpreter()
 
-# Save current settings
-interpreter.save_config("~/my_settings.py")
+Load from custom profile:
+
+>>> config = Config.from_file("~/custom_profile.py")
+>>> interpreter = Interpreter(config)
+
+Save current settings:
+
+>>> interpreter.save_config("~/my_settings.py")
 """
 
 # Use lazy imports to avoid loading heavy modules immediately

--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -270,10 +270,16 @@ def parse_args():
             subprocess.run([opener, profile_dir])
         sys.exit(0)
 
+    # If custom profile specified, load it and update args
     if args["profile"] != profile.profile_path:
-        profile.load(args["profile"])
+        # Load the specified profile, ignoring any defaults
+        profile = Profile.from_file(args["profile"])
+        # Find which settings were explicitly set via command line flags
+        cli_provided = {k for k,v in parser._option_string_actions.items()
+                       if v.dest in args and sys.argv.__contains__(k)}
+        # Update args with profile values, preserving any CLI overrides
         for key, value in vars(profile).items():
-            if key in args and args[key] is None:
+            if key in args and key not in cli_provided:
                 args[key] = value
 
     if args["save"]:

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -93,17 +93,20 @@ class Interpreter:
     --------
     >>> from interpreter import Interpreter
 
-    # Basic usage
-    interpreter = Interpreter()
-    interpreter.chat()
+    Basic usage:
 
-    # With custom configuration
-    from interpreter import Profile
-    profile = Profile.from_file("~/custom_profile.py")
-    interpreter = Interpreter(profile)
+    >>> interpreter = Interpreter()
+    >>> interpreter.chat()
 
-    # Save settings for later
-    interpreter.save_profile("~/my_settings.py")
+    With custom configuration:
+
+    >>> from interpreter import Profile
+    >>> profile = Profile.from_file("~/custom_profile.py")
+    >>> interpreter = Interpreter(profile)
+
+    Save settings for later:
+
+    >>> interpreter.save_profile("~/my_settings.py")
 
     Parameters
     ----------

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -99,11 +99,11 @@ class Interpreter:
 
     # With custom configuration
     from interpreter import Profile
-    profile = Profile.from_file("~/custom_profile.json")
+    profile = Profile.from_file("~/custom_profile.py")
     interpreter = Interpreter(profile)
 
     # Save settings for later
-    interpreter.save_profile("~/my_settings.json")
+    interpreter.save_profile("~/my_settings.py")
 
     Parameters
     ----------
@@ -152,7 +152,7 @@ class Interpreter:
         Load settings from a profile file
 
         Example:
-        >>> interpreter.load_profile("~/work_settings.json")
+        >>> interpreter.load_profile("~/work_settings.py")
         """
         self._profile.load(path)
         # Update interpreter attributes from new profile
@@ -164,7 +164,7 @@ class Interpreter:
         Save current settings as a profile
 
         Example:
-        >>> interpreter.save_profile("~/my_preferred_settings.json")
+        >>> interpreter.save_profile("~/my_preferred_settings.py")
         """
         # Update profile object with current values
         self._profile.from_dict(self.to_dict())
@@ -177,7 +177,7 @@ class Interpreter:
         Create new interpreter instance from a profile file
 
         Example:
-        >>> interpreter = Interpreter.from_profile("~/work_settings.json")
+        >>> interpreter = Interpreter.from_profile("~/work_settings.py")
         """
         return cls(Profile.from_file(path))
 

--- a/interpreter/misc/welcome.py
+++ b/interpreter/misc/welcome.py
@@ -254,9 +254,9 @@ Execute natural language commands on your computer
     --serve               Start in server mode
 
 example: interpreter "create a python script"
-example: interpreter -m gpt-4 "analyze data.csv" 
+example: interpreter -m gpt-4 "analyze data.csv"
 example: interpreter --auto-run "install nodejs"
-example: interpreter --profile work.json
+example: interpreter --profile work.py
 """
     )
 
@@ -282,9 +282,9 @@ Execute natural language commands on your computer
     --serve               Start in server mode
 
 example: interpreter "create a python script"
-example: interpreter -m gpt-4 "analyze data.csv" 
+example: interpreter -m gpt-4 "analyze data.csv"
 example: interpreter --auto-run "install nodejs"
-example: interpreter --profile work.json
+example: interpreter --profile work.py
 """
     )
 

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -69,7 +69,7 @@ class Profile:
         # Debug settings
         self.debug = False  # Whether to enable debug mode
 
-        # Set default path but don't load from it
+        # Initialize with default path (which may be overridden in from_file)
         self.profile_path = self.DEFAULT_PROFILE_PATH
 
     def to_dict(self):
@@ -136,6 +136,9 @@ class Profile:
             ):
                 return
             raise FileNotFoundError(f"Profile file not found at {path}")
+        else:
+            # Update profile_path when loading succeeds
+            self.profile_path = os.path.abspath(path)
 
         # Create a temporary namespace to execute the profile in
         namespace = {}
@@ -171,4 +174,6 @@ class Profile:
         """Create a new profile instance from a file"""
         profile = cls()
         profile.load(path)
+        # Update profile_path after successful load
+        profile.profile_path = os.path.abspath(os.path.expanduser(path))
         return profile

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -16,14 +16,17 @@ class Profile:
     --------
     >>> from interpreter import Profile
 
-    # Load defaults (and ~/.openinterpreter if it exists)
-    profile = Profile()
+    Load defaults (and ~/.openinterpreter if it exists):
 
-    # Load from specific profile
-    profile = Profile.from_file("~/custom_profile.py")
+    >>> profile = Profile()
 
-    # Save current settings
-    profile.save("~/my_settings.py")
+    Load from specific profile:
+
+    >>> profile = Profile.from_file("~/custom_profile.py")
+
+    Save current settings:
+
+    >>> profile.save("~/my_settings.py")
     """
 
     DEFAULT_PROFILE_FOLDER = "~/.openinterpreter"

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -20,10 +20,10 @@ class Profile:
     profile = Profile()
 
     # Load from specific profile
-    profile = Profile.from_file("~/custom_profile.json")
+    profile = Profile.from_file("~/custom_profile.py")
 
     # Save current settings
-    profile.save("~/my_settings.json")
+    profile.save("~/my_settings.py")
     """
 
     DEFAULT_PROFILE_FOLDER = "~/.openinterpreter"

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -132,7 +132,8 @@ class Profile:
             path += ".py"
 
         if not os.path.exists(path):
-            # If file doesn't exist, if it's the default, that's fine
+            # If the missing file is the default profile path, that's fine -
+            # we'll use the defaults from __init__
             if os.path.abspath(os.path.expanduser(path)) == os.path.abspath(
                 os.path.expanduser(self.DEFAULT_PROFILE_PATH)
             ):

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -1,8 +1,5 @@
-import json
 import os
-import platform
 import sys
-from datetime import datetime
 
 
 class Profile:

--- a/interpreter/profiles.py
+++ b/interpreter/profiles.py
@@ -147,7 +147,9 @@ class Profile:
                 # This avoids loading the full interpreter module which is resource intensive
                 content = content.replace(
                     "from interpreter import interpreter",
-                    "class Interpreter:\n    pass\ninterpreter = Interpreter()",
+                    "class Interpreter:\n"
+                    "    pass\n"
+                    "interpreter = Interpreter()",
                 )
 
                 # Execute the modified profile content


### PR DESCRIPTION
### Describe the changes you have made:

dependent on https://github.com/OpenInterpreter/open-interpreter/pull/1612

1. Update profile.profile_path to the actual path

Previously it was keeping the default:

profile_path: ~/.openinterpreter\default_profile.py

because interpreter.profile_path is not an attribute that would be set
within the profile file, but is a property *of* that file.

2. Prevent profile from being overridden by defaults

Previously, when loading a custom profile via --profile, its settings
could be overridden by defaults from the initial Profile() instance
because argparse was initialized with those defaults, and
only None-valued arguments would be updated from the custom profile.
This caused issues like custom model settings being reset to the default
claude-3-5-sonnet-20241022.

This change:
- Creates a fresh Profile instance when loading custom profiles
- Tracks which arguments were explicitly provided via CLI
- Updates args from profile unless explicitly set via CLI

This ensures profile settings take precedence over defaults while
still allowing CLI arguments to override profile settings.

Example:
Before: Custom profile with model="gpt-4o-mini" would be overridden
by default model="claude-3-5-sonnet-20241022" unless --model was
explicitly set on command line.

After: Custom profile settings are preserved unless explicitly
overridden by command line arguments.

The provider auto-detection still works as expected:
- If profile sets both model and provider: uses those values
- If profile sets only model: provider=None allows auto-detection


### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
