### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ sources require the provider credentials documented in the
 ## License
 
 Apache-2.0
-> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.

--- a/README.md
+++ b/README.md
@@ -142,3 +142,4 @@ sources require the provider credentials documented in the
 ## License
 
 Apache-2.0
+> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,6 +149,8 @@ wire_api = "chat"
 
 Set `APPNZ_API_KEY` to your app.nz API key.
 
+> **Note:** The same OpenAI-compatible `base_url` pattern works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=open-interpreter&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
+
 ## Harness
 
 Open Interpreter adds a `harness` setting for compatibility modes that shape

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,7 +149,7 @@ wire_api = "chat"
 
 Set `APPNZ_API_KEY` to your app.nz API key.
 
-> **Note:** The same OpenAI-compatible `base_url` pattern works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=open-interpreter&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
+> **Note:** The same OpenAI-compatible `base_url` pattern works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 ## Harness
 


### PR DESCRIPTION
Clarify that the OpenAI Python client base_url pattern works with [repo] and with other OpenAI-compatible multi-model gateways, using DaoXE (https://api.daoxe.com/v1) as one concrete example. Docs only. Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>