### PR TITLE
feat(core): set AI_AGENT for shell commands

### DIFF
--- a/codex-rs/core/src/exec_env.rs
+++ b/codex-rs/core/src/exec_env.rs
@@ -8,6 +8,9 @@ use std::collections::HashMap;
 
 pub use codex_protocol::shell_environment::CODEX_THREAD_ID_ENV_VAR;
 
+const AI_AGENT_ENV_VAR: &str = "AI_AGENT";
+const OPEN_INTERPRETER_AI_AGENT: &str = "open-interpreter";
+
 /// Informational name of the active permission profile. Child processes can
 /// overwrite this value, so it must not be treated as proof of enforcement.
 pub const CODEX_PERMISSION_PROFILE_ENV_VAR: &str = "CODEX_PERMISSION_PROFILE";
@@ -21,13 +24,36 @@ pub const CODEX_PERMISSION_PROFILE_ENV_VAR: &str = "CODEX_PERMISSION_PROFILE";
 /// for [`ShellEnvironmentPolicy`].
 ///
 /// `CODEX_THREAD_ID` is injected when a thread id is provided, even when
-/// `include_only` is set.
+/// `include_only` is set. `AI_AGENT` is always present so child processes can
+/// detect Open Interpreter through a vendor-neutral marker.
 pub fn create_env(
     policy: &ShellEnvironmentPolicy,
     thread_id: Option<ThreadId>,
 ) -> HashMap<String, String> {
     let thread_id = thread_id.map(|thread_id| thread_id.to_string());
-    shell_environment::create_env(policy, thread_id.as_deref())
+    let mut env = shell_environment::create_env(policy, thread_id.as_deref());
+    inject_ai_agent_env(&mut env);
+    env
+}
+
+fn inject_ai_agent_env(env: &mut HashMap<String, String>) {
+    let existing = env.iter().find(|(key, _)| {
+        if cfg!(windows) {
+            key.eq_ignore_ascii_case(AI_AGENT_ENV_VAR)
+        } else {
+            key.as_str() == AI_AGENT_ENV_VAR
+        }
+    });
+    if existing.is_some_and(|(_, value)| !value.trim().is_empty()) {
+        return;
+    }
+    if cfg!(windows) {
+        env.retain(|key, _| !key.eq_ignore_ascii_case(AI_AGENT_ENV_VAR));
+    }
+    env.insert(
+        AI_AGENT_ENV_VAR.to_string(),
+        OPEN_INTERPRETER_AI_AGENT.to_string(),
+    );
 }
 
 /// Injects the selected named permission profile into a shell tool's environment.

--- a/codex-rs/core/src/exec_env_tests.rs
+++ b/codex-rs/core/src/exec_env_tests.rs
@@ -11,6 +11,27 @@ fn make_vars(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
 }
 
 #[test]
+fn inject_ai_agent_env_sets_open_interpreter_marker() {
+    let mut env = HashMap::new();
+
+    inject_ai_agent_env(&mut env);
+
+    assert_eq!(
+        env.get(AI_AGENT_ENV_VAR).map(String::as_str),
+        Some("open-interpreter")
+    );
+}
+
+#[test]
+fn inject_ai_agent_env_preserves_explicit_marker() {
+    let mut env = HashMap::from([(AI_AGENT_ENV_VAR.to_string(), "wrapper".to_string())]);
+
+    inject_ai_agent_env(&mut env);
+
+    assert_eq!(env.get(AI_AGENT_ENV_VAR).map(String::as_str), Some("wrapper"));
+}
+
+#[test]
 fn inject_permission_profile_env_overrides_policy_value() {
     let mut env = HashMap::from([(
         CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),


### PR DESCRIPTION
## Summary

- expose `AI_AGENT=open-interpreter` to shell commands launched by Open Interpreter
- preserve an explicit non-blank marker supplied by a wrapper or orchestrator
- handle case-insensitive Windows environment keys without leaving duplicates
- add focused coverage for the default and preservation behavior

## Why a universal marker

Tools launched by coding agents often need to adapt telemetry, UX, logging, or safety behavior based on whether they are running under an agent. Today they generally have to maintain agent-specific process-tree and environment heuristics. A shared `AI_AGENT=<slug>` convention lets the producer that already knows its identity declare it once, avoiding an N-by-M matrix of consumer heuristics as agents and tools multiply.

This is deliberately an advisory marker, not a security boundary. Open Interpreter only supplies its own slug when the variable is missing or blank, so wrappers and higher-level orchestrators retain control of any explicit non-blank value.

## Validation

- `git diff --check`
- attempted `bazel test --test_output=errors --test_filter=exec_env //codex-rs/core:core-unit-tests`; repository analysis stops before compilation because `codex_rust_crate()` rejects the existing `binary_test_target_compatible_with` argument in `codex-rs/windows-sandbox-rs/BUILD.bazel`
- attempted the repository formatter; this checkout environment does not provide its required `just`, Cargo, or dotslash tools
