### PR TITLE
Fix update prompt after upstream helper removal

### DIFF
--- a/codex-rs/tui/src/update_prompt.rs
+++ b/codex-rs/tui/src/update_prompt.rs
@@ -1,6 +1,5 @@
 #![cfg(not(debug_assertions))]
 
-use crate::history_cell::padded_emoji;
 use crate::key_hint;
 use crate::legacy_core::config::Config;
 use crate::render::Insets;
@@ -191,7 +190,7 @@ impl WidgetRef for &UpdatePromptScreen {
 
         column.push("");
         column.push(Line::from(vec![
-            padded_emoji("  ✨").bold().cyan(),
+            "  ✨\u{200A}".bold().cyan(),
             "Update available!".bold(),
             " ".into(),
             format!(


### PR DESCRIPTION
Restores the upstream inline hair-space rendering in the branded update prompt while preserving Open Interpreter's product-specific update source. The upstream helper was removed during the Codex sync, but the branded update-channel delta accidentally reintroduced its old call, causing release builds to fail in codex-tui.