### PR TITLE
Release Open Interpreter 0.0.39

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-core",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -2298,11 +2298,11 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.0.38"
+version = "0.0.39"
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "cc",
  "libc",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2761,11 +2761,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.38"
+version = "0.0.39"
 
 [[package]]
 name = "codex-config"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-test-support"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-exec-server",
  "codex-http-client",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "keyring",
  "tracing",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "clap",
  "codex-core",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-core",
  "codex-http-client",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -4030,14 +4030,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "age",
  "anyhow",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-config",
  "codex-core-skills",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4368,7 +4368,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4575,7 +4575,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "dirs",
  "dunce",
@@ -4601,14 +4601,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "lru 0.16.3",
  "sha1 0.10.6",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "clap",
  "codex-product-info",
@@ -4653,15 +4653,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.38"
+version = "0.0.39"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.38"
+version = "0.0.39"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4779,14 +4779,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4805,14 +4805,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4822,14 +4822,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -137,7 +137,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.38"
+version = "0.0.39"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.38 -> 9.9.9                                                                   │
+│ ✨ Update available! 0.0.39 -> 9.9.9                                                                   │
 │ Run sh -c 'curl -fsSL https://www.openinterpreter.com/install | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                        │
 │ See full release notes:                                                                                │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.38 -> 9.9.9            │
+│ ✨ Update available! 0.0.39 -> 9.9.9            │
 │ Run pnpm add -g @openai/codex to update.        │
 │                                                 │
 │ See full release notes:                         │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭───────────────────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.38)                         │
+│ >_ OpenAI Codex (v0.0.39)                         │
 │                                                   │
 │ model:     test-provider gpt-5   /model to change │
 │ directory: /tmp/project                           │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.38 -> 9.9.9                                                                │
+│ ✨ Update available! 0.0.39 -> 9.9.9                                                                │
 │ Run sh -c 'curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                     │
 │ See full release notes:                                                                             │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.38 -> 9.9.9                                                                       │
+│ ✨ Update available! 0.0.39 -> 9.9.9                                                                       │
 │ Run powershell -ExecutionPolicy Bypass -c '$env:CODEX_NON_INTERACTIVE=1; irm                               │
 │ https://chatgpt.com/codex/install.ps1 | iex' to update.                                                    │
 │                                                                                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                        │
+│  >_ OpenAI Codex (v0.0.39)                                                        │
 │                                                                                   │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                     │
 │ information on rate limits and credits                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                │
+│  >_ OpenAI Codex (v0.0.39)                                                │
 │                                                                           │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date             │
 │ information on rate limits and credits                                    │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                            │
+│  >_ OpenAI Codex (v0.0.39)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                            │
+│  >_ OpenAI Codex (v0.0.39)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                               │
+│  >_ OpenAI Codex (v0.0.39)                                               │
 │                                                                          │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
 │ information on rate limits and credits                                   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_halfwidth_kana_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_halfwidth_kana_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)             │
+│  >_ OpenAI Codex (v0.0.39)             │
 │                                        │
 │ Visit                                  │
 │ https://chatgpt.com/codex/settings/usa │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                         │
+│  >_ OpenAI Codex (v0.0.39)                                         │
 │                                                                    │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date      │
 │ information on rate limits and credits                             │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                  │
+│  >_ OpenAI Codex (v0.0.39)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                   │
+│  >_ OpenAI Codex (v0.0.39)                                                   │
 │                                                                              │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                │
 │ information on rate limits and credits                                       │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                 │
+│  >_ OpenAI Codex (v0.0.39)                 │
 │                                            │
 │ Visit                                      │
 │ https://chatgpt.com/codex/settings/usage   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__transcript_overlay_status_rate_limit_refresh.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__transcript_overlay_status_rate_limit_refresh.snap
@@ -7,7 +7,7 @@ before:
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                               │
+│  >_ OpenAI Codex (v0.0.39)                                               │
 │                                                                          │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
 │ information on rate limits and credits                                   │
@@ -39,7 +39,7 @@ after:
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.38)                                                │
+│  >_ OpenAI Codex (v0.0.39)                                                │
 │                                                                           │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date             │
 │ information on rate limits and credits                                    │


### PR DESCRIPTION
Bumps the Open Interpreter workspace and user-visible version snapshots to 0.0.39 after merging the product-branding release. Local validation: `just fmt`; `just test -p codex-tui` (3,418 passed, 4 skipped; one retry passed).