### PR TITLE
Fix authenticated provider model picker cache hang

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "codex-models-manager",
  "codex-otel",
  "codex-plugin",
+ "codex-product-info",
  "codex-protocol",
  "codex-rmcp-client",
  "codex-rollout",

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -74,6 +74,7 @@ codex-mcp-extension = { workspace = true }
 codex-model-provider = { workspace = true }
 codex-model-provider-info = { workspace = true }
 codex-models-manager = { workspace = true }
+codex-product-info = { workspace = true }
 codex-protocol = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 codex-app-server-transport = { workspace = true }

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -41,6 +41,11 @@ pub async fn supported_models_for_provider(
     provider_config.model_provider = provider;
     provider_config.codex_home = config.codex_home.join("models-cache").join(provider_id);
     let models_manager = build_models_manager(&provider_config, auth_manager);
+    if codex_product_info::Product::current() == codex_product_info::Product::OpenInterpreter
+        && let Some(models) = models_manager.list_models_from_cache_if_present().await
+    {
+        return models_from_presets(models, include_hidden);
+    }
     models_from_presets(
         models_manager
             .list_models(RefreshStrategy::OnlineIfUncached, http_client_factory)

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -114,6 +114,16 @@ pub trait ModelsManager: fmt::Debug + Send + Sync {
         http_client_factory: HttpClientFactory,
     ) -> ModelsManagerFuture<'_, ModelsResponse>;
 
+    /// Return picker-ready models when a fresh cache entry is available, without resolving auth.
+    ///
+    /// Product integrations may use this fast path before invoking the normal refresh flow when
+    /// loading stored authentication is not required to display an already-cached catalog.
+    fn list_models_from_cache_if_present(
+        &self,
+    ) -> ModelsManagerFuture<'_, Option<Vec<ModelPreset>>> {
+        Box::pin(async { None })
+    }
+
     /// Return the current in-memory remote model catalog without refreshing or loading cache state.
     fn get_remote_models(&self) -> ModelsManagerFuture<'_, Vec<ModelInfo>>;
 
@@ -397,6 +407,17 @@ impl ModelsManager for OpenAiModelsManager {
 
     fn get_remote_models(&self) -> ModelsManagerFuture<'_, Vec<ModelInfo>> {
         Box::pin(async move { self.remote_models.read().await.clone() })
+    }
+
+    fn list_models_from_cache_if_present(
+        &self,
+    ) -> ModelsManagerFuture<'_, Option<Vec<ModelPreset>>> {
+        Box::pin(async move {
+            if !self.try_load_cache().await {
+                return None;
+            }
+            Some(self.build_available_models(self.get_remote_models().await))
+        })
     }
 
     fn try_get_remote_models(&self) -> Result<Vec<ModelInfo>, TryLockError> {

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -463,6 +463,35 @@ async fn injected_cache_hit_avoids_remote_fetch() {
 }
 
 #[tokio::test]
+async fn cache_first_picker_models_do_not_require_auth_resolution() {
+    let cached_models = vec![remote_model("cached", "Cached", /*priority*/ 0)];
+    let cache = TestModelsCache::with_entry(ModelsCacheEntry {
+        fetched_at: Utc::now(),
+        etag: None,
+        client_version: Some(crate::client_version_to_whole()),
+        models: cached_models.clone(),
+    });
+    let endpoint = TestModelsEndpoint::new(vec![vec![remote_model(
+        "remote", "Remote", /*priority*/ 0,
+    )]]);
+    let manager = OpenAiModelsManager::new_with_cache(
+        cache,
+        endpoint.clone(),
+        Some(AuthManager::from_auth_for_testing(
+            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        )),
+    );
+
+    let models = manager
+        .list_models_from_cache_if_present()
+        .await
+        .expect("fresh cache should provide picker models");
+
+    assert_eq!(models[0].model, "cached");
+    assert_eq!(endpoint.fetch_count(), 0);
+}
+
+#[tokio::test]
 async fn injected_cache_read_error_falls_back_and_persists_remote_models() {
     let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
     let cache = TestModelsCache::failing(/*load_error*/ true, /*store_error*/ false);


### PR DESCRIPTION
Fixes #1875.

Provider-specific model listing now checks a fresh provider cache before resolving stored authentication. This prevents `/model` from waiting on auth resolution when usable cached models are already available.

Scope:
- Open Interpreter provider-picker integration only
- no generic Codex behavior changes
- no generated provider/catalog changes

Validation:
- codex-models-manager tests: 62 passed
- clippy passed for changed crates
- codex-app-server compiled successfully