### PR TITLE
Release Open Interpreter 0.0.40

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-core",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -2298,11 +2298,11 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.0.39"
+version = "0.0.40"
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "serde",
  "serde_json",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "codex-build-info"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-install-context",
  "pretty_assertions",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "cc",
  "libc",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2792,11 +2792,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.39"
+version = "0.0.40"
 
 [[package]]
 name = "codex-config"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "codex-diagnostics"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-test-support"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-exec-server",
  "codex-http-client",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian-v2"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "codex-history"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-protocol",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "keyring",
  "tracing",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "clap",
  "codex-core",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-core",
  "codex-http-client",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-config",
  "memchr",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -4091,14 +4091,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "codex-queue-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-core",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "age",
  "anyhow",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-analytics",
  "codex-config",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "dirs",
  "dunce",
@@ -4687,14 +4687,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "lru 0.16.4",
  "sha1 0.10.6",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "clap",
  "codex-product-info",
@@ -4739,15 +4739,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.39"
+version = "0.0.40"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.39"
+version = "0.0.40"
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -4865,14 +4865,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -4891,14 +4891,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -4908,14 +4908,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "codex-workload-identity"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "codex-http-client",
  "pretty_assertions",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9467,7 +9467,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -142,7 +142,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.39"
+version = "0.0.40"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__open_interpreter_standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.39 -> 9.9.9                                                                   │
+│ ✨ Update available! 0.0.40 -> 9.9.9                                                                   │
 │ Run sh -c 'curl -fsSL https://www.openinterpreter.com/install | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                        │
 │ See full release notes:                                                                                │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__pnpm_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.39 -> 9.9.9            │
+│ ✨ Update available! 0.0.40 -> 9.9.9            │
 │ Run pnpm add -g @openai/codex to update.        │
 │                                                 │
 │ See full release notes:                         │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭───────────────────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.39)                         │
+│ >_ OpenAI Codex (v0.0.40)                         │
 │                                                   │
 │ model:     test-provider gpt-5   /model to change │
 │ directory: /tmp/project                           │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_unix_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.39 -> 9.9.9                                                                │
+│ ✨ Update available! 0.0.40 -> 9.9.9                                                                │
 │ Run sh -c 'curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh' to update. │
 │                                                                                                     │
 │ See full release notes:                                                                             │

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__standalone_windows_update_available_history_cell_snapshot.snap
@@ -3,7 +3,7 @@ source: tui/src/history_cell/tests.rs
 expression: rendered
 ---
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ✨ Update available! 0.0.39 -> 9.9.9                                                                       │
+│ ✨ Update available! 0.0.40 -> 9.9.9                                                                       │
 │ Run powershell -ExecutionPolicy Bypass -c '$env:CODEX_NON_INTERACTIVE=1; irm                               │
 │ https://chatgpt.com/codex/install.ps1 | iex' to update.                                                    │
 │                                                                                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_enterprise_monthly_credit_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                        │
+│  >_ OpenAI Codex (v0.0.40)                                                        │
 │                                                                                   │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                     │
 │ information on rate limits and credits                                            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                │
+│  >_ OpenAI Codex (v0.0.40)                                                │
 │                                                                           │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date             │
 │ information on rate limits and credits                                    │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                            │
+│  >_ OpenAI Codex (v0.0.40)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                            │
+│  >_ OpenAI Codex (v0.0.40)                                            │
 │                                                                       │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
 │ information on rate limits and credits                                │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_chatgpt_plan_without_email.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                               │
+│  >_ OpenAI Codex (v0.0.40)                                               │
 │                                                                          │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
 │ information on rate limits and credits                                   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_halfwidth_kana_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_halfwidth_kana_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)             │
+│  >_ OpenAI Codex (v0.0.40)             │
 │                                        │
 │ Visit                                  │
 │ https://chatgpt.com/codex/settings/usa │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                         │
+│  >_ OpenAI Codex (v0.0.40)                                         │
 │                                                                    │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date      │
 │ information on rate limits and credits                             │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                  │
+│  >_ OpenAI Codex (v0.0.40)                                                  │
 │                                                                             │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
 │ information on rate limits and credits                                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                   │
+│  >_ OpenAI Codex (v0.0.40)                                                   │
 │                                                                              │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date                │
 │ information on rate limits and credits                                       │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_wraps_enterprise_monthly_credit_details_in_narrow_terminal.snap
@@ -5,7 +5,7 @@ expression: sanitized
 /status
 
 ╭────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                 │
+│  >_ OpenAI Codex (v0.0.40)                 │
 │                                            │
 │ Visit                                      │
 │ https://chatgpt.com/codex/settings/usage   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__transcript_overlay_status_rate_limit_refresh.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__transcript_overlay_status_rate_limit_refresh.snap
@@ -7,7 +7,7 @@ before:
 /status
 
 ╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                               │
+│  >_ OpenAI Codex (v0.0.40)                                               │
 │                                                                          │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
 │ information on rate limits and credits                                   │
@@ -39,7 +39,7 @@ after:
 /status
 
 ╭───────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.39)                                                │
+│  >_ OpenAI Codex (v0.0.40)                                                │
 │                                                                           │
 │ Visit https://chatgpt.com/codex/settings/usage for up-to-date             │
 │ information on rate limits and credits                                    │


### PR DESCRIPTION
## Open Interpreter boundary

- [x] I read `AGENTS.md` and `README.md`.
- [x] This is release metadata for Open Interpreter, not a change to general Codex behavior.
- [x] I considered whether this belongs in `openai/codex`; it does not.
- [x] This change is specific to Open Interpreter standalone packaging and update discovery.

## Why this belongs in Open Interpreter

This prepares the Open Interpreter release version consumed by its standalone packages, updater, and TUI update notices after the stable Codex `rust-v0.148.0` integration.

## Summary

- bump the Rust workspace from 0.0.39 to 0.0.40
- update the lockfile and version-bearing TUI snapshots
- keep the release delta limited to Open Interpreter release metadata

## Test plan

- `cargo fmt --check`
- `just fmt`
- locked Cargo metadata resolves the workspace as 0.0.40
- no remaining 0.0.39 references
- `git diff --check`
- full public Linux and Windows CI