### PR TITLE
fix(product-info): advertise the embedded Codex 0.148.0 version

### DIFF
--- a/codex-rs/models-manager/src/lib.rs
+++ b/codex-rs/models-manager/src/lib.rs
@@ -38,7 +38,7 @@ mod tests {
     fn open_interpreter_advertises_embedded_codex_compatibility_version() {
         assert_eq!(
             client_version_to_whole_for_product(codex_product_info::Product::OpenInterpreter),
-            "0.147.0"
+            "0.148.0"
         );
     }
 }

--- a/codex-rs/product-info/src/lib.rs
+++ b/codex-rs/product-info/src/lib.rs
@@ -7,7 +7,7 @@ pub const OPEN_INTERPRETER_NON_INTERACTIVE_ENV_VAR: &str = "OPEN_INTERPRETER_NON
 ///
 /// Open Interpreter has an independent product version, so backend compatibility
 /// checks must not interpret that product version as the embedded Codex version.
-pub const OPEN_INTERPRETER_CODEX_COMPATIBILITY_VERSION: &str = "0.147.0";
+pub const OPEN_INTERPRETER_CODEX_COMPATIBILITY_VERSION: &str = "0.148.0";
 
 const CODEX_RELEASE_NOTES_URL: &str = "https://github.com/openai/codex/releases/latest";
 const OPEN_INTERPRETER_RELEASE_NOTES_URL: &str =


### PR DESCRIPTION
## Before opening this pull request

- [x] I considered whether this change belongs in `openai/codex`.
- [x] This change is specific to an Open Interpreter-owned surface, or I have
      linked the upstream Codex contribution below.

## Why this belongs in Open Interpreter

`OPEN_INTERPRETER_CODEX_COMPATIBILITY_VERSION` does not exist in Codex. It exists only because Open Interpreter carries an independent product version, and its own doc comment says so:

> Open Interpreter has an independent product version, so backend compatibility checks must not interpret that product version as the embedded Codex version.

Nothing about upstream Codex behavior changes here — this is the branding/compatibility surface described in the template.

## Summary

The constant is documented as the *"upstream Codex release whose client behavior is embedded in Open Interpreter"*, and it is what gets reported to Codex services:

- the `version` HTTP header on the OpenAI provider (`model-provider-info`)
- the build version in the User-Agent (`login/src/auth/default_client.rs`)
- `client_version` for the app server (`tui`, `exec`, `acp-server`, `app-server-daemon`)

Every previous sync moved it together with the vendored tree — `git log -L 10,10:codex-rs/product-info/src/lib.rs` shows the line changing in each one:

| Value | Commit |
|---|---|
| `0.144.4` | Rebase Open Interpreter onto Codex 0.144.4 |
| `0.144.5` | Merge Codex 0.144.5 stable release |
| `0.145.0` | Merge Codex rust-v0.145.0 |
| `0.146.0` | Merge Codex rust-v0.146.0 |
| `0.147.0` | Merge Codex rust-v0.147.0 into Open Interpreter 0.0.35 |

`Sync official Codex rust-v0.148.0` (f00e2e0d) touched no file under `codex-rs/product-info/`, so the sixth sync is the first that left it behind. Released 0.0.40 therefore ships 0.148.0 client behavior while telling the backend it is a 0.147.0 client — the precise mismatch the constant exists to prevent.

This bumps it to `0.148.0` to match the vendored tree.

## Related issue

None — found by comparing the constant against the sync history. Happy to close this if 0.147.0 is deliberately pinned to the last backend-validated release rather than to the vendored tree; in that case the doc comment is what needs the edit, and I'd be glad to send that instead.

## Test plan

```
cargo test -p codex-models-manager -p codex-product-info --lib   # 61 + 3 pass
cargo test -p codex-model-provider-info --lib                    # 34 pass
```

`models-manager` has the one test that covers this, `open_interpreter_advertises_embedded_codex_compatibility_version`. It pins the same literal, so it tracked the constant rather than the vendored tree and could not detect the drift — reverting only `product-info` while leaving the test at the new value shows it is genuinely bound:

```
assertion `left == right` failed
  left: "0.147.0"
 right: "0.148.0"
```

Worth noting for the future: nothing in the repo records the vendored Codex version in machine-readable form, so no check can catch this drift on its own — the test can only restate whatever the constant says. If you'd like, I can follow up with an anchor (for example the synced tag in a small metadata file) so the next sync fails loudly instead of silently shipping a stale version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
