### PR TITLE
docs: fix dead Portability link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Open Interpreter ships with a QA skill that lets any model operate and test inte
   - [Z.AI, GLM, and ZCode](https://www.openinterpreter.com/docs/terminal/zai-glm?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=zai_glm_docs)
 - [Agent Client Protocol](https://www.openinterpreter.com/docs/terminal/acp)
 - [Codex SDK](https://www.openinterpreter.com/docs/terminal/sdk)
-- [Portability](https://www.openinterpreter.com/docs/terminal/portability)
+- [Portability](https://github.com/openinterpreter/openinterpreter/blob/main/docs/portability.md)
 - [Sandbox & approvals](https://www.openinterpreter.com/docs/terminal/sandbox?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=sandbox_approvals)
 - [Branding a distribution fork](FORK_BRANDING.md)
 


### PR DESCRIPTION
The Portability link in the README returns **HTTP 404** — the page isn't deployed on the docs site (all sibling `/docs/terminal/*` pages are live, this one is missing from the nav). The source document exists in-repo, so the link now points there: `docs/portability.md` (the file's frontmatter matches: "How Open Interpreter uses shared agent standards and avoids product lock-in"). If the site page gets deployed later, the link can move back.
