### PR TITLE
fix: restore chat compatibility transport for non-Responses wires

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -75,6 +75,7 @@ use codex_otel::SessionTelemetry;
 use codex_otel::current_span_w3c_trace_context;
 use codex_protocol::auth::AuthMode;
 
+use codex_chat_wire_compat::ToolKinds;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_protocol::config_types::Verbosity as VerbosityConfig;
@@ -88,6 +89,7 @@ use codex_protocol::protocol::W3cTraceContext;
 use codex_rollout_trace::CompactionTraceContext;
 use codex_rollout_trace::InferenceTraceAttempt;
 use codex_rollout_trace::InferenceTraceContext;
+use codex_tools::Harness;
 use codex_tools::create_tools_json_for_responses_api;
 use codex_tools::create_tools_json_for_responses_lite;
 use codex_tools::create_tools_raw_json_for_responses_api;
@@ -116,9 +118,17 @@ use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
 use crate::client_common::ResponseStream;
 use crate::feedback_tags;
+use crate::harness::request::ChatHarnessRequest;
+use crate::harness::request::ChatHarnessTurn;
+use crate::harness::request::apply_chat_harness_postprocess;
+use crate::harness::request::build_chat_harness_request;
+use crate::harness::routing::ChatHarnessRoute;
+use crate::harness::routing::StreamTransportRoute;
+use crate::harness::routing::resolve_stream_transport_route;
 use crate::responses_metadata::CodexResponsesMetadata;
 use crate::responses_metadata::subagent_header_value;
 use crate::util::emit_feedback_auth_recovery_tags;
+use codex_chat_wire_compat::ChatCompletionsCompatClient;
 use codex_feedback::FeedbackRequestTags;
 use codex_feedback::emit_feedback_request_tags_with_auth_env;
 use codex_login::auth::AgentIdentityAuthPolicy;
@@ -131,7 +141,6 @@ use codex_model_provider::create_model_provider;
 #[cfg(test)]
 use codex_model_provider_info::DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS;
 use codex_model_provider_info::ModelProviderInfo;
-use codex_model_provider_info::WireApi;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result;
 use codex_response_debug_context::extract_response_debug_context;
@@ -160,6 +169,7 @@ const X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER: &str =
 const REALTIME_CALLS_ENDPOINT: &str = "/realtime/calls";
 const RESPONSES_ENDPOINT: &str = "/responses";
 const RESPONSES_COMPACT_ENDPOINT: &str = "/responses/compact";
+const CHAT_COMPLETIONS_ENDPOINT: &str = "/chat/completions";
 // `/responses/compact` is unary, so the timeout covers the full response rather than one idle
 // period between stream events.
 const COMPACT_REQUEST_TIMEOUT_IDLE_MULTIPLIER: u32 = 4;
@@ -256,6 +266,8 @@ pub struct ModelClient {
     agent_identity_policy: AgentIdentityAuthPolicy,
     prompt_cache_key_override: Option<String>,
     http_client_factory: HttpClientFactory,
+    harness: Harness,
+    harness_guidance: bool,
 }
 
 /// A turn-scoped streaming session created from a [`ModelClient`].
@@ -470,7 +482,15 @@ impl ModelClient {
             agent_identity_policy,
             prompt_cache_key_override: None,
             http_client_factory,
+            harness: Harness::Native,
+            harness_guidance: true,
         }
+    }
+
+    pub(crate) fn with_harness(mut self, harness: Harness, harness_guidance: bool) -> Self {
+        self.harness = harness;
+        self.harness_guidance = harness_guidance;
+        self
     }
 
     pub(crate) fn with_prompt_cache_key_override(
@@ -1027,6 +1047,10 @@ impl ModelClient {
 
     pub(crate) async fn prewarm_auth(&self) -> Result<()> {
         self.current_client_setup().await.map(|_| ())
+    }
+
+    fn stream_transport_route(&self) -> Result<StreamTransportRoute> {
+        resolve_stream_transport_route(self.state.provider.info().wire_api, &self.harness)
     }
 
     /// Opens a websocket connection using the same header and telemetry wiring as normal turns.
@@ -1859,9 +1883,8 @@ impl ModelClientSession {
         responses_metadata: &CodexResponsesMetadata,
         inference_trace: &InferenceTraceContext,
     ) -> Result<ResponseStream> {
-        let wire_api = self.client.state.provider.info().wire_api;
-        match wire_api {
-            WireApi::Responses => {
+        match self.client.stream_transport_route()? {
+            StreamTransportRoute::ResponsesApi => {
                 if self.client.responses_websocket_enabled() {
                     let request_trace = current_span_w3c_trace_context();
                     match self
@@ -1898,9 +1921,286 @@ impl ModelClientSession {
                 )
                 .await
             }
-            WireApi::Chat | WireApi::Messages => Err(CodexErr::UnsupportedOperation(
+            StreamTransportRoute::ChatCompletionsCompat => {
+                self.stream_chat_completions_compat(
+                    prompt,
+                    model_info,
+                    session_telemetry,
+                    effort,
+                    summary,
+                    service_tier,
+                    responses_metadata,
+                    inference_trace,
+                )
+                .await
+            }
+            StreamTransportRoute::ChatHarness(route) => {
+                Box::pin(self.stream_chat_harness_api(
+                    route,
+                    prompt,
+                    model_info,
+                    session_telemetry,
+                    effort,
+                ))
+                .await
+            }
+            StreamTransportRoute::MessagesHarness(_)
+            | StreamTransportRoute::ClaudeCodeResponses(_)
+            | StreamTransportRoute::ClaudeCodeChat(_) => Err(CodexErr::UnsupportedOperation(
                 "non-Responses wire APIs require the compatibility transport".to_string(),
             )),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(
+        name = "model_client.stream_chat_completions_compat",
+        level = "info",
+        skip_all,
+        fields(
+            model = %model_info.slug,
+            wire_api = %self.client.state.provider.info().wire_api,
+            transport = "chat_completions_http",
+            http.method = "POST",
+            api.path = "chat/completions"
+        )
+    )]
+    async fn stream_chat_completions_compat(
+        &self,
+        prompt: &Prompt,
+        model_info: &ModelInfo,
+        session_telemetry: &SessionTelemetry,
+        effort: Option<ReasoningEffortConfig>,
+        summary: ReasoningSummaryConfig,
+        service_tier: Option<String>,
+        responses_metadata: &CodexResponsesMetadata,
+        inference_trace: &InferenceTraceContext,
+    ) -> Result<ResponseStream> {
+        let auth_manager = self.client.state.provider.auth_manager();
+        let mut auth_recovery = auth_manager
+            .as_ref()
+            .map(AuthManager::unauthorized_recovery);
+        let mut pending_retry = PendingUnauthorizedRetry::default();
+        loop {
+            let client_setup = self.client.current_client_setup().await?;
+            let transport = self
+                .client
+                .build_api_transport(&client_setup.api_provider, CHAT_COMPLETIONS_ENDPOINT)?;
+            let request_auth_context = AuthRequestTelemetryContext::new(
+                client_setup.auth.as_ref().map(CodexAuth::auth_mode),
+                client_setup.api_auth.as_ref(),
+                client_setup.agent_identity_telemetry.clone(),
+                pending_retry,
+            );
+            let (request_telemetry, sse_telemetry) = Self::build_streaming_telemetry(
+                session_telemetry,
+                request_auth_context,
+                RequestRouteTelemetry::for_endpoint(CHAT_COMPLETIONS_ENDPOINT),
+                self.client.state.auth_env_telemetry.clone(),
+            );
+            let compression = self.responses_request_compression(client_setup.auth.as_ref());
+            let mut options = self
+                .build_responses_options(
+                    responses_metadata,
+                    compression,
+                    model_info.use_responses_lite,
+                )
+                .await;
+
+            let mut request = self.client.build_responses_request(
+                prompt,
+                model_info,
+                effort.clone(),
+                summary,
+                service_tier.clone(),
+                responses_metadata,
+            )?;
+            self.client
+                .prepare_response_items_for_request(&mut request.input);
+            let request_session_telemetry =
+                session_telemetry_for_request(session_telemetry, &request);
+            let inference_trace_attempt = inference_trace.start_attempt();
+            inference_trace_attempt.add_request_headers(&mut options.extra_headers);
+            inference_trace_attempt.record_started(&request);
+            let client = ChatCompletionsCompatClient::new(
+                transport,
+                client_setup.api_provider,
+                client_setup.api_auth,
+            )
+            .with_telemetry(Some(request_telemetry), Some(sse_telemetry));
+            let stream_result = client.stream_request(request, options).await;
+
+            match stream_result {
+                Ok(stream) => {
+                    let (stream, _) = map_response_stream(
+                        stream,
+                        request_session_telemetry,
+                        inference_trace_attempt,
+                        Arc::clone(&self.client.state.provider),
+                    );
+                    return Ok(stream);
+                }
+                Err(ApiError::Transport(
+                    unauthorized_transport @ TransportError::Http { status, .. },
+                )) if status == StatusCode::UNAUTHORIZED => {
+                    let response_debug_context =
+                        extract_response_debug_context(&unauthorized_transport);
+                    inference_trace_attempt.record_failed(
+                        &unauthorized_transport,
+                        response_debug_context.request_id.as_deref(),
+                        /*output_items*/ &[],
+                    );
+                    pending_retry = PendingUnauthorizedRetry::from_recovery(
+                        handle_unauthorized(
+                            unauthorized_transport,
+                            &mut auth_recovery,
+                            session_telemetry,
+                            &self.client.state.provider,
+                        )
+                        .await?,
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    let response_debug_context =
+                        extract_response_debug_context_from_api_error(&err);
+                    let err = self.client.state.provider.map_api_error(err);
+                    inference_trace_attempt.record_failed(
+                        &err,
+                        response_debug_context.request_id.as_deref(),
+                        /*output_items*/ &[],
+                    );
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    async fn stream_chat_harness_api(
+        &self,
+        route: ChatHarnessRoute,
+        prompt: &Prompt,
+        model_info: &ModelInfo,
+        session_telemetry: &SessionTelemetry,
+        effort: Option<ReasoningEffortConfig>,
+    ) -> Result<ResponseStream> {
+        let auth_manager = self.client.state.provider.auth_manager();
+        let mut auth_recovery = auth_manager
+            .as_ref()
+            .map(AuthManager::unauthorized_recovery);
+        let mut pending_retry = PendingUnauthorizedRetry::default();
+        loop {
+            let client_setup = self.client.current_client_setup().await?;
+            let transport = self
+                .client
+                .build_api_transport(&client_setup.api_provider, CHAT_COMPLETIONS_ENDPOINT)?;
+            let request_auth_context = AuthRequestTelemetryContext::new(
+                client_setup.auth.as_ref().map(CodexAuth::auth_mode),
+                client_setup.api_auth.as_ref(),
+                client_setup.agent_identity_telemetry.clone(),
+                pending_retry,
+            );
+            let (request_telemetry, sse_telemetry) = Self::build_streaming_telemetry(
+                session_telemetry,
+                request_auth_context,
+                RequestRouteTelemetry::for_endpoint(CHAT_COMPLETIONS_ENDPOINT),
+                self.client.state.auth_env_telemetry.clone(),
+            );
+            let thread_id = self.client.state.thread_id.to_string();
+            let ChatHarnessRequest {
+                request_body,
+                tool_kinds,
+                title_request,
+                postprocess,
+            } = build_chat_harness_request(
+                route,
+                ChatHarnessTurn {
+                    prompt,
+                    harness: &self.client.harness,
+                    harness_guidance: self.client.harness_guidance,
+                    model_info,
+                    effort: effort.clone(),
+                    thread_id: &thread_id,
+                    session_source: Some(&self.client.state.session_source),
+                },
+            )?;
+            let client = ChatCompletionsCompatClient::new(
+                transport,
+                client_setup.api_provider,
+                client_setup.api_auth,
+            )
+            .with_telemetry(Some(request_telemetry), Some(sse_telemetry));
+            if let Some(title_request) = title_request {
+                match client
+                    .stream_chat_request_value(
+                        title_request,
+                        ToolKinds::new(),
+                        self.chat_harness_options(),
+                    )
+                    .await
+                {
+                    Ok(mut title_stream) => {
+                        while let Some(event) = title_stream.next().await {
+                            event.map_err(|err| self.client.state.provider.map_api_error(err))?;
+                        }
+                    }
+                    Err(ApiError::Transport(
+                        unauthorized_transport @ TransportError::Http { status, .. },
+                    )) if status == StatusCode::UNAUTHORIZED => {
+                        pending_retry = PendingUnauthorizedRetry::from_recovery(
+                            handle_unauthorized(
+                                unauthorized_transport,
+                                &mut auth_recovery,
+                                session_telemetry,
+                                &self.client.state.provider,
+                            )
+                            .await?,
+                        );
+                        continue;
+                    }
+                    Err(err) => return Err(self.client.state.provider.map_api_error(err)),
+                }
+            }
+            match client
+                .stream_chat_request_value(request_body, tool_kinds, self.chat_harness_options())
+                .await
+            {
+                Ok(stream) => {
+                    let (stream, _) = map_response_stream(
+                        stream,
+                        session_telemetry.clone(),
+                        InferenceTraceAttempt::disabled(),
+                        Arc::clone(&self.client.state.provider),
+                    );
+                    return Ok(apply_chat_harness_postprocess(stream, postprocess));
+                }
+                Err(ApiError::Transport(
+                    unauthorized_transport @ TransportError::Http { status, .. },
+                )) if status == StatusCode::UNAUTHORIZED => {
+                    pending_retry = PendingUnauthorizedRetry::from_recovery(
+                        handle_unauthorized(
+                            unauthorized_transport,
+                            &mut auth_recovery,
+                            session_telemetry,
+                            &self.client.state.provider,
+                        )
+                        .await?,
+                    );
+                }
+                Err(err) => return Err(self.client.state.provider.map_api_error(err)),
+            }
+        }
+    }
+
+    fn chat_harness_options(&self) -> ApiResponsesOptions {
+        let thread_id = self.client.state.thread_id.to_string();
+        ApiResponsesOptions {
+            session_id: Some(thread_id.clone()),
+            thread_id: Some(thread_id),
+            session_source: Some(self.client.state.session_source.clone()),
+            extra_headers: ApiHeaderMap::new(),
+            compression: Compression::None,
+            turn_state: None,
         }
     }
 
@@ -2498,3 +2798,7 @@ impl WebsocketTelemetry for ApiTelemetry {
 #[cfg(test)]
 #[path = "client_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "client_chat_transport_tests.rs"]
+mod client_chat_transport_tests;

--- a/codex-rs/core/src/client_chat_transport_tests.rs
+++ b/codex-rs/core/src/client_chat_transport_tests.rs
@@ -1,0 +1,419 @@
+use super::ModelClient;
+use super::Prompt;
+use crate::client_common::ResponseEvent;
+use crate::responses_metadata::CodexResponsesMetadata;
+use crate::test_support::TestCodexResponsesRequestKind;
+use crate::test_support::responses_metadata as test_responses_metadata;
+use codex_http_client::HttpClientFactory;
+use codex_http_client::OutboundProxyPolicy;
+use codex_login::auth::AgentIdentityAuthPolicy;
+use codex_model_provider_info::WireApi;
+use codex_model_provider_info::create_oss_provider_with_base_url;
+use codex_otel::SessionTelemetry;
+use codex_protocol::ThreadId;
+use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::error::CodexErr;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::openai_models::ModelInfo;
+use codex_protocol::protocol::SessionSource;
+use codex_rollout_trace::InferenceTraceContext;
+use codex_tools::Harness;
+use futures::StreamExt;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+fn test_model_info(slug: &str) -> ModelInfo {
+    serde_json::from_value(json!({
+        "slug": slug,
+        "display_name": slug,
+        "description": "desc",
+        "default_reasoning_level": "medium",
+        "supported_reasoning_levels": [
+            {"effort": "medium", "description": "medium"}
+        ],
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "supported_in_api": true,
+        "priority": 1,
+        "upgrade": null,
+        "model_messages": null,
+        "support_verbosity": false,
+        "default_verbosity": null,
+        "apply_patch_tool_type": null,
+        "truncation_policy": {"mode": "bytes", "limit": 10000},
+        "supports_image_detail_original": false,
+        "context_window": 272000,
+        "auto_compact_token_limit": null,
+        "experimental_supported_tools": []
+    }))
+    .expect("deserialize test model info")
+}
+
+fn test_session_telemetry() -> SessionTelemetry {
+    SessionTelemetry::new(
+        ThreadId::new(),
+        "gpt-test",
+        "gpt-test",
+        /*account_id*/ None,
+        /*account_email*/ None,
+        /*auth_mode*/ None,
+        "test-originator".to_string(),
+        /*log_user_prompts*/ false,
+        "test-terminal".to_string(),
+        SessionSource::Cli,
+    )
+}
+
+fn user_prompt(text: &str) -> Prompt {
+    Prompt {
+        input: vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: text.to_string(),
+            }],
+            phase: None,
+            internal_chat_message_metadata_passthrough: None,
+        }],
+        ..Prompt::default()
+    }
+}
+
+fn chat_sse(chunks: Vec<Value>) -> String {
+    let mut body = chunks
+        .into_iter()
+        .map(|chunk| format!("data: {chunk}\n\n"))
+        .collect::<String>();
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+fn assistant_text_sse(id: &str, model: &str, text: &str) -> String {
+    chat_sse(vec![
+        json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": { "role": "assistant", "content": text },
+                "finish_reason": null
+            }]
+        }),
+        json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop"
+            }]
+        }),
+    ])
+}
+
+fn bash_tool_call_sse(id: &str, model: &str, call_id: &str) -> String {
+    let arguments = json!({ "command": "pwd" }).to_string();
+    chat_sse(vec![
+        json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": arguments
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        }),
+        json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "tool_calls"
+            }]
+        }),
+    ])
+}
+
+fn chat_model_client(base_url: &str, harness: Harness) -> ModelClient {
+    let provider = create_oss_provider_with_base_url(base_url, WireApi::Chat);
+    ModelClient::new(
+        /*auth_manager*/ None,
+        AgentIdentityAuthPolicy::JwtOnly,
+        ThreadId::new(),
+        provider,
+        SessionSource::Cli,
+        "test_originator".to_string(),
+        /*model_verbosity*/ None,
+        /*enable_request_compression*/ false,
+        /*include_timing_metrics*/ false,
+        /*beta_features_header*/ None,
+        /*concurrent_reasoning_summaries_enabled*/ false,
+        /*attestation_provider*/ None,
+        HttpClientFactory::new(OutboundProxyPolicy::ReqwestDefault),
+    )
+    .with_harness(harness, /*harness_guidance*/ true)
+}
+
+fn responses_metadata_for(client: &ModelClient) -> CodexResponsesMetadata {
+    let thread_id = client.state.thread_id.to_string();
+    test_responses_metadata(
+        TEST_INSTALLATION_ID,
+        &thread_id,
+        &thread_id,
+        /*turn_id*/ Some("turn-1"),
+        format!("{thread_id}:0"),
+        &client.state.session_source,
+        /*parent_thread_id*/ None,
+        TestCodexResponsesRequestKind::Turn,
+    )
+}
+
+async fn collect_stream_events(
+    client: ModelClient,
+    model_slug: &str,
+    prompt: Prompt,
+) -> Result<Vec<ResponseEvent>, CodexErr> {
+    let metadata = responses_metadata_for(&client);
+    let mut session = client.new_session();
+    let mut stream = session
+        .stream(
+            &prompt,
+            &test_model_info(model_slug),
+            &test_session_telemetry(),
+            /*effort*/ None,
+            ReasoningSummary::None,
+            /*service_tier*/ None,
+            &metadata,
+            &InferenceTraceContext::disabled(),
+        )
+        .await?;
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event?);
+    }
+    Ok(events)
+}
+
+async fn chat_bodies(server: &MockServer, path: &str) -> Vec<Value> {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|request| request.url.path() == path)
+        .map(|request| serde_json::from_slice(&request.body).expect("chat request json"))
+        .collect()
+}
+
+#[tokio::test]
+async fn moonshot_k3_kimi_code_tool_turn_uses_chat_completions() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(bash_tool_call_sse("chatcmpl-k3-tool", "kimi-k3", "bash:0")),
+        )
+        .expect(/*requests*/ 1)
+        .mount(&server)
+        .await;
+
+    let client = chat_model_client(&format!("{}/v1", server.uri()), Harness::KimiCode);
+    let events = collect_stream_events(
+        client,
+        "kimi-k3",
+        user_prompt("Run pwd using the shell and report the result. Do not modify files."),
+    )
+    .await
+    .expect("Moonshot K3 tool turn should use the chat compatibility transport");
+
+    let bodies = chat_bodies(&server, "/v1/chat/completions").await;
+    assert_eq!(bodies.len(), 1);
+    assert_eq!(bodies[0]["model"], "kimi-k3");
+    let tools = bodies[0]["tools"]
+        .as_array()
+        .expect("kimi-code request should include tools");
+    assert!(
+        tools.iter().any(|tool| tool["function"]["name"] == "Bash"),
+        "kimi-code tool surface should include Bash: {tools:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            ResponseEvent::OutputItemDone(ResponseItem::FunctionCall { name, .. })
+                if name == "Bash"
+        )),
+        "expected Bash tool call in stream: {events:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn chat_wire_native_hello_uses_chat_completions() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(assistant_text_sse(
+                    "chatcmpl-native-hello",
+                    "deepseek-v4-flash",
+                    "hello",
+                )),
+        )
+        .expect(/*requests*/ 1)
+        .mount(&server)
+        .await;
+
+    let client = chat_model_client(&format!("{}/v1", server.uri()), Harness::Native);
+    let events = collect_stream_events(client, "deepseek-v4-flash", user_prompt("hello"))
+        .await
+        .expect("chat-wire native hello should use the chat compatibility transport");
+
+    let bodies = chat_bodies(&server, "/v1/chat/completions").await;
+    assert_eq!(bodies.len(), 1);
+    assert_eq!(bodies[0]["model"], "deepseek-v4-flash");
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            ResponseEvent::OutputItemDone(ResponseItem::Message { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    ContentItem::OutputText { text } if text.contains("hello")
+                ))
+        )),
+        "expected assistant hello in stream: {events:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn chat_wire_minimal_hello_uses_chat_completions() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(assistant_text_sse(
+                    "chatcmpl-minimal-hello",
+                    "deepseek-v4-flash",
+                    "hello",
+                )),
+        )
+        .expect(/*requests*/ 1)
+        .mount(&server)
+        .await;
+
+    let client = chat_model_client(&format!("{}/v1", server.uri()), Harness::Minimal);
+    collect_stream_events(client, "deepseek-v4-flash", user_prompt("hello"))
+        .await
+        .expect("chat-wire minimal hello should use the chat compatibility transport");
+
+    let bodies = chat_bodies(&server, "/v1/chat/completions").await;
+    assert_eq!(bodies.len(), 1);
+    let messages = bodies[0]["messages"]
+        .as_array()
+        .expect("minimal harness should send chat messages");
+    assert!(
+        messages.iter().any(|message| message["role"] == "system"
+            && message["content"]
+                .as_str()
+                .is_some_and(|text| text.contains("expert software engineer"))),
+        "minimal harness should shape a system prompt: {messages:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn chat_wire_custom_harness_hello_uses_chat_completions() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(assistant_text_sse(
+                    "chatcmpl-custom-hello",
+                    "deepseek-v4-flash",
+                    "hello",
+                )),
+        )
+        .expect(/*requests*/ 1)
+        .mount(&server)
+        .await;
+
+    let client = chat_model_client(
+        &format!("{}/v1", server.uri()),
+        Harness::Other("persona-external".to_string()),
+    );
+    collect_stream_events(client, "deepseek-v4-flash", user_prompt("hello"))
+        .await
+        .expect("custom chat-wire harness hello should use the chat compatibility transport");
+
+    assert_eq!(chat_bodies(&server, "/v1/chat/completions").await.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn open_webui_chat_wire_hello_uses_chat_completions() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/openai/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(assistant_text_sse(
+                    "chatcmpl-open-webui",
+                    "local-model",
+                    "hello",
+                )),
+        )
+        .expect(/*requests*/ 1)
+        .mount(&server)
+        .await;
+
+    let client = chat_model_client(&format!("{}/openai/v1", server.uri()), Harness::Native);
+    collect_stream_events(client, "local-model", user_prompt("hello"))
+        .await
+        .expect("Open WebUI chat-wire hello should use the chat compatibility transport");
+
+    assert_eq!(
+        chat_bodies(&server, "/openai/v1/chat/completions")
+            .await
+            .len(),
+        1
+    );
+    Ok(())
+}

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -26,6 +26,7 @@ use codex_protocol::protocol::ThreadHistoryMode;
 use codex_protocol::protocol::ThreadSource;
 use codex_protocol::protocol::TurnEnvironmentSelections;
 use codex_skills::SkillError;
+use codex_tools::Harness;
 use std::sync::OnceLock;
 use tokio::sync::Semaphore;
 
@@ -1298,6 +1299,10 @@ impl Session {
                         .enabled(Feature::ConcurrentReasoningSummaries),
                     attestation_provider,
                     config.http_client_factory(),
+                )
+                .with_harness(
+                    Harness::from_config_name(config.harness.as_deref()),
+                    config.harness_guidance,
                 )
                 .with_prompt_cache_key_override(
                     crate::guardian::prompt_cache_key_override_for_review_session(


### PR DESCRIPTION
## Summary

After the 0.148.0 Codex rust sync, `ModelClientSession::stream()` only handled `WireApi::Responses`. Chat-wire providers (Moonshot K3 / `kimi-code`, native, minimal, custom harness, Open WebUI) failed immediately with `unsupported operation: non-Responses wire APIs require the compatibility transport` before any HTTP request was sent.

The harness routing and chat-completions compatibility client were still in the tree; they just had no production caller. This restores dispatch:

- `WireApi::Chat` + native / custom harness → `ChatCompletionsCompat`
- `WireApi::Chat` + known harnesses (`kimi-code`, `minimal`, …) → `stream_chat_harness_api`
- Session construction now threads the configured harness into `ModelClient`

## Tests

`cargo test -p codex-core --lib client::` (19 passed), including coverage for:

- Moonshot K3 / `kimi-code` tool turn
- chat-wire native hello
- chat-wire minimal hello
- custom harness hello
- Open WebUI chat-wire hello

Fixes #1883