### PR TITLE
docs: clarify Ollama tool use and verify CLI completions

### DIFF
--- a/codex-rs/cli/tests/product_identity.rs
+++ b/codex-rs/cli/tests/product_identity.rs
@@ -114,6 +114,10 @@ fn interpreter_help_version_errors_and_completions_keep_product_identity() -> an
             stdout.to_ascii_lowercase().contains("interpreter"),
             "{shell} completion should target interpreter: {stdout}"
         );
+        assert!(
+            stdout.contains("--chat-completions"),
+            "{shell} completion should include --chat-completions: {stdout}"
+        );
     }
     Ok(())
 }

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -68,6 +68,24 @@ interpreter exec --json "list the files this task would touch"
 Each line is a JSON event representing progress, tool calls, file changes,
 reasoning summaries, or the final message.
 
+## Completion And Exit Status
+
+A zero exit status means the agent turn reached the protocol's completed state.
+It does not prove that an arbitrary instruction's intended side effect happened.
+For example, a local model can return a normal final message without creating a
+file that the prompt requested.
+
+Use `--verify` to ask for an additional completion-check turn when appropriate,
+and make automation check its required outputs directly:
+
+```bash
+interpreter exec --verify "create NOTES.md summarizing this project"
+test -s NOTES.md
+```
+
+With local models, also ensure the model server's active context is large enough
+for the full agent prompt and tool schemas. See [Local model tool use](/docs/models#local-model-tool-use).
+
 ## Structured Output
 
 Pair `--output-schema` with a schema file:

--- a/docs/models.md
+++ b/docs/models.md
@@ -136,6 +136,35 @@ Use `--local-provider ollama` for a remote Ollama server. Do not create a
 separate `model_providers` entry just to change the address of either built-in
 local provider; `CODEX_OSS_BASE_URL` is the supported override.
 
+### Local model tool use
+
+Agent prompts include instructions and tool schemas in addition to your text.
+Make sure the local server's active context window is large enough for that
+complete request. For example, a model trained for a 32K context can still run
+with Ollama's smaller server default unless you raise it before starting the
+server:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=32768 ollama serve
+```
+
+If the server truncates the beginning of the request, a model may answer from
+guesses, print a tool call as ordinary text, or ask you to run a command instead
+of invoking a tool. These are model/server compatibility symptoms, not evidence
+that the requested filesystem action happened.
+
+The `qwen-code` harness uses the Chat Completions transport. For Qwen models on
+Ollama, select that transport explicitly so the inferred Qwen harness can use
+its native request shape:
+
+```bash
+interpreter exec --oss --local-provider ollama --chat-completions \
+  -m qwen2.5-coder:7b "inspect this project"
+```
+
+For automated work, also verify the expected files or other side effects after
+the command exits. See [Non-Interactive Mode](/docs/exec#completion-and-exit-status).
+
 ### Model metadata warnings
 
 `Model metadata for ... not found` means the local server returned a model ID

--- a/docs/zh/exec.md
+++ b/docs/zh/exec.md
@@ -65,6 +65,19 @@ interpreter exec --json "list the files this task would touch"
 
 每一行都是一个 JSON 事件，表示进度、工具调用、文件更改、推理摘要或最终消息。
 
+## 完成状态与退出码
+
+退出码为零表示 agent 回合已到达协议定义的完成状态，并不能证明任意指令所要求的副作用已经发生。例如，本地模型可能返回正常的最终消息，却没有创建提示词要求的文件。
+
+适用时可使用 `--verify` 请求额外的完成检查回合，同时让自动化流程直接检查必要的输出：
+
+```bash
+interpreter exec --verify "create NOTES.md summarizing this project"
+test -s NOTES.md
+```
+
+使用本地模型时，还应确保模型服务器实际启用的上下文窗口足以容纳完整的 agent 提示词和工具 schema。请参阅[本地模型的工具调用](/docs/models#本地模型的工具调用)。
+
 ## 结构化输出
 
 配合 `--output-schema` 使用模式文件：

--- a/docs/zh/models.md
+++ b/docs/zh/models.md
@@ -121,6 +121,25 @@ CODEX_OSS_BASE_URL=http://192.168.1.20:1234/v1 \
 
 远程 Ollama 服务器请使用 `--local-provider ollama`。不要仅仅为了更改任一内置本地提供者的地址而创建单独的 `model_providers` 条目；`CODEX_OSS_BASE_URL` 才是受支持的覆盖方式。
 
+### 本地模型的工具调用
+
+Agent 提示词除了用户输入外，还包含指令和工具 schema。请确保本地服务器实际启用的上下文窗口足以容纳完整请求。例如，即使模型训练时支持 32K 上下文，Ollama 仍可能以较小的服务器默认值运行；可在启动服务器前提高该值：
+
+```bash
+OLLAMA_CONTEXT_LENGTH=32768 ollama serve
+```
+
+如果服务器截断了请求开头，模型可能会猜测文件内容、把工具调用作为普通文本输出，或者要求用户代为运行命令，而不是实际调用工具。这些现象表示模型或服务器存在兼容性问题，并不能证明请求的文件系统操作已经发生。
+
+`qwen-code` harness 使用 Chat Completions 传输。通过 Ollama 使用 Qwen 模型时，请显式选择该传输，使自动推断的 Qwen harness 能使用其原生请求格式：
+
+```bash
+interpreter exec --oss --local-provider ollama --chat-completions \
+  -m qwen2.5-coder:7b "inspect this project"
+```
+
+在自动化任务中，还应在命令退出后直接检查预期文件或其他副作用。请参阅[非交互模式](/docs/exec#完成状态与退出码)。
+
 ### 模型元数据警告
 
 `Model metadata for ... not found` 表示本地服务器返回的模型 ID 未在 Open Interpreter 的兼容性目录中。它本身并不意味着服务器连接失败。请确认服务器暴露的准确 ID，使用相同的值通过 `-m` 传入，并更新 Open Interpreter 以获得最新目录。Open Interpreter 可以继续使用回退元数据，但某些模型特定的控制或行为可能不可用。

--- a/scripts/codex_package/smoke_tests/smoke_cli_archive.py
+++ b/scripts/codex_package/smoke_tests/smoke_cli_archive.py
@@ -1,0 +1,79 @@
+"""Smoke-test the public command surface of an assembled CLI archive."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+SHELLS = ("bash", "zsh", "fish", "powershell")
+
+
+def run(entrypoint: Path, root: Path, environment: dict[str, str], *args: str) -> str:
+    completed = subprocess.run(
+        [str(entrypoint), *args],
+        cwd=root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    return f"{completed.stdout}\n{completed.stderr}"
+
+
+def assert_open_interpreter_surface(label: str, output: str) -> None:
+    assert "codex" not in output.casefold(), f"{label} leaked Codex branding:\n{output}"
+
+
+def smoke_open_interpreter(root: Path, entrypoint: Path) -> None:
+    environment = dict(os.environ)
+    environment["INTERPRETER_HOME"] = str(root / "interpreter-home")
+    environment.pop("CODEX_HOME", None)
+
+    root_help = run(entrypoint, root, environment, "--help")
+    exec_help = run(entrypoint, root, environment, "exec", "--help")
+    version = run(entrypoint, root, environment, "--version")
+    for label, output in (
+        ("root help", root_help),
+        ("exec help", exec_help),
+        ("version", version),
+    ):
+        assert_open_interpreter_surface(label, output)
+    assert "--chat-completions" in root_help
+    assert "--chat-completions" in exec_help
+    assert version.strip().startswith("interpreter "), version
+
+    for shell in SHELLS:
+        completion = run(entrypoint, root, environment, "completion", shell)
+        assert_open_interpreter_surface(f"{shell} completion", completion)
+        assert "interpreter" in completion.casefold(), completion
+        assert "--chat-completions" in completion, completion
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument(
+        "--product", choices=("open-interpreter",), required=True
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="cli-package-smoke-") as temp:
+        root = Path(temp)
+        with tarfile.open(args.archive, "r:gz") as archive:
+            archive.extractall(root, filter="data")
+        metadata = json.loads((root / "codex-package.json").read_text())
+        assert metadata["variant"] == args.product, metadata
+        entrypoint = root / metadata["entrypoint"]
+        assert entrypoint.name in {"interpreter", "interpreter.exe"}, entrypoint
+        smoke_open_interpreter(root, entrypoint)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- document Ollama context sizing for reliable local-model tool use
- document the Qwen Chat Completions invocation
- clarify exec completion versus verification of requested side effects
- require `--chat-completions` in generated shell-completion tests
- add an archive-level CLI smoke-test helper

## Validation

- documentation locale check
- CLI option inheritance tests (22 passed)
- Python smoke helper syntax and argument parsing
- clean diff validation

Closes #1889.