### PR TITLE
Release Open Interpreter 0.0.42

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,45 @@
+# Open Interpreter 0.0.42
+
+Open Interpreter 0.0.42 improves provider and transport discoverability,
+keeps the command-line experience consistently branded, and adds a reusable
+diagnostic harness for Ollama-backed Qwen tool-use checks. It is based on the
+stable upstream Codex `rust-v0.153.4` compatibility baseline.
+
+## Models
+
+- **Inherited upstream presets:** `gpt-6-astra`, `gpt-5.6-sol`,
+  `gpt-5.6-terra`, and `gpt-5.6-luna`. These exact IDs and their metadata are
+  inherited from upstream Codex; Open Interpreter does not add aliases for
+  them, and availability still depends on the selected provider and account.
+- **Google AI Studio IDs:** `gemini-3.8-flash`, `gemini-3.7-flash`,
+  `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, and
+  `gemini-3.1-flash-lite`. These are provider-documented IDs surfaced in the
+  [model guide](docs/models.md), not Open Interpreter-owned model aliases.
+- **Z.AI IDs:** `glm-5.2` and `glm-5-turbo`. These are the provider-documented
+  starting IDs; use the exact ID returned by the selected Z.AI service or plan.
+  Generic Z.AI uses Chat Completions, while the separate ZCode setup uses its
+  compatible Messages endpoint.
+- Open Interpreter's OIX-specific work here is provider/catalog, transport,
+  harness, and product integration. The list above is not a promise that every
+  provider, region, account, wire API, or harness accepts every ID. Use `/model`
+  and the active provider's model list as the final authority.
+
+## CLI and branding
+
+- Chat Completions is easier to find and select through root help, `exec` help,
+  provider guidance, and generated Bash, Zsh, Fish, and PowerShell completions.
+- User-facing help, version, errors, cloud guidance, and diagnostics identify
+  Open Interpreter consistently. Compatibility names remain only where they
+  describe an upstream protocol, crate, model, or configuration alias.
+- `exec` configuration help explains user configuration loading more clearly.
+
+## Local model diagnostics
+
+- `scripts/ollama_qwen_smoke.py` provides a reusable, generic Ollama diagnostic
+  harness for Qwen tool-use checks. It bounds captured output, cleans up timed
+  out process groups, records tool-call signals, and verifies requested file
+  side effects separately from an assistant's final message.
+- Its deterministic Python tests are cheap enough for routine checks. Live
+  Ollama inference is intentionally opt-in for a relevant model report,
+  transport/tool-use change, or fix validation, and may require generous
+  timeouts for slow local inference.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,8 @@ stable upstream Codex `rust-v0.153.4` compatibility baseline.
   `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, and
   `gemini-3.1-flash-lite`. These are provider-documented IDs surfaced in the
   [model guide](docs/models.md), not Open Interpreter-owned model aliases.
-- **Z.AI IDs:** `glm-5.2` and `glm-5-turbo`. These are the provider-documented
+- **Anthropic IDs:** `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, and `claude-haiku-4-5-20251001`. These are current active provider-documented IDs surfaced in the model guide.
+- **Z.AI IDs:** `glm-5.1`, `glm-5`, `glm-5-turbo`, and the free/lightweight `glm-4.7-flash`. These are the provider-documented
   starting IDs; use the exact ID returned by the selected Z.AI service or plan.
   Generic Z.AI uses Chat Completions, while the separate ZCode setup uses its
   compatible Messages endpoint.

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "codex-acp-server"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-core",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-roles"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-config",
  "codex-file-system",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-daemon"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -2340,11 +2340,11 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.0.41"
+version = "0.0.42"
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
  "tokio",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "serde",
  "serde_json",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "codex-build-info"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-install-context",
  "pretty_assertions",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "codex-bwrap"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "cc",
  "libc",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chat-wire-compat"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "bytes",
  "codex-api",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-mock-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-cloud-tasks-client",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-code-mode-protocol",
@@ -2841,11 +2841,11 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.0.41"
+version = "0.0.42"
 
 [[package]]
 name = "codex-config"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "codex-config-schema"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-api"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-analytics",
  "codex-app-server-protocol",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "codex-diagnostics"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-test-support"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-utils-absolute-path",
  "pretty_assertions",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "notify",
  "pretty_assertions",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian-context"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "pretty_assertions",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian-v2"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "codex-history"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-protocol",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "codex-history-notes-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-api",
  "codex-client",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "bytes",
  "codex-utils-cargo-bin",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "keyring",
  "tracing",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "clap",
  "codex-core",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-core",
  "codex-http-client",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "codex-message-history"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-config",
  "memchr",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-api",
  "codex-product-info",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel-trace-websocket"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -4230,14 +4230,14 @@ dependencies = [
 
 [[package]]
 name = "codex-product-info"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chardetng",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "codex-queue-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-core",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "codex-realtime-webrtc"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-install-context",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4446,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "appcontainer_common",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "age",
  "anyhow",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "assert_matches",
  "codex-analytics",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-uds",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
  "tracing",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "codex-test-binary-support"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-arg0",
  "tempfile",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-manager-sample"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "codex-thread-store"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "async-io",
  "pretty_assertions",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "dirs",
  "dunce",
@@ -4849,14 +4849,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "lru 0.16.4",
  "sha1 0.10.6",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cargo-bin"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "assert_cmd",
  "runfiles",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "clap",
  "codex-product-info",
@@ -4901,15 +4901,15 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-elapsed"
-version = "0.0.41"
+version = "0.0.42"
 
 [[package]]
 name = "codex-utils-fuzzy-match"
-version = "0.0.41"
+version = "0.0.42"
 
 [[package]]
 name = "codex-utils-git-discovery"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-git-utils",
  "codex-utils-absolute-path",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-product-info",
  "codex-utils-absolute-path",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-oss"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-core",
  "codex-lmstudio",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "assert_matches",
  "thiserror 2.0.18",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-redacted-string"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -5048,14 +5048,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-sandbox-summary"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-sleep-inhibitor"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "core-foundation 0.9.4",
  "libc",
@@ -5074,14 +5074,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -5091,14 +5091,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "codex-v8-poc"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "pretty_assertions",
  "v8",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "codex-voice-host"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-install-context",
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-http-client",
  "codex-utils-rustls-provider",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "codex-workload-identity"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "codex-http-client",
  "pretty_assertions",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "codex-worktree"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-git-utils",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "core_test_support"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9749,7 +9749,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "anyhow",
  "codex-login",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "codex-http-client",
  "codex-login",
  "codex-model-provider",
+ "codex-product-info",
  "codex-tui",
  "codex-utils-cli",
  "crossterm",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -151,7 +151,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.41"
+version = "0.0.42"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -24,7 +24,7 @@ pub use login::run_logout;
 
 #[derive(Debug, Default, Args)]
 pub struct SandboxStateArgs {
-    /// JSON value from `codex/sandbox-state-meta` to apply directly.
+    /// JSON sandbox-state metadata to apply directly.
     #[arg(
         long = "sandbox-state-json",
         value_name = "JSON",

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -289,7 +289,7 @@ pub fn read_api_key_from_stdin() -> String {
 pub fn read_access_token_from_stdin() -> String {
     read_stdin_secret(
         &format!(
-            "--with-access-token expects the access token on stdin. Try piping it, e.g. `printenv CODEX_ACCESS_TOKEN | {} login --with-access-token`.",
+            "--with-access-token expects the access token on stdin. Pipe the token into `{} login --with-access-token`.",
             codex_product_info::Product::current().command_name()
         ),
         "Reading access token from stdin...",

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -167,6 +167,10 @@ enum Subcommand {
     App(app_cmd::AppCommand),
 
     /// Generate shell completion scripts.
+    #[clap(
+        about = completion_about(),
+        after_help = completion_examples()
+    )]
     Completion(CompletionCommand),
 
     /// Update to the latest version.
@@ -1047,9 +1051,22 @@ fn product_command_name() -> &'static str {
 }
 
 fn product_about() -> String {
+    let command = product_command_name();
+    let display_name = codex_product_info::Product::current().display_name();
     format!(
-        "{}\n\nIf no subcommand is specified, options will be forwarded to the interactive CLI.",
-        codex_product_info::Product::current().display_name()
+        "{display_name}\n\nIf no subcommand is specified, options will be forwarded to the interactive CLI.\n\nExamples:\n  {command} completion bash > {command}.bash\n  {command} --chat-completions"
+    )
+}
+
+fn completion_about() -> String {
+    let command = product_command_name();
+    format!("Generate shell completion scripts for {command}.")
+}
+
+fn completion_examples() -> String {
+    let command = product_command_name();
+    format!(
+        "Examples:\n  source <({command} completion bash)\n  {command} completion zsh > _{command}\n  {command} completion fish > ~/.config/fish/completions/{command}.fish"
     )
 }
 

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -640,7 +640,7 @@ struct ExecServerCommand {
     #[arg(long = "name", value_name = "NAME", global = true)]
     name: Option<String>,
 
-    /// Use Agent Identity auth from CODEX_ACCESS_TOKEN for remote registration.
+    /// Use the configured Agent Identity access token for remote registration.
     #[arg(
         long = "use-agent-identity-auth",
         requires = "exec_server_remote",
@@ -683,7 +683,7 @@ enum AppServerSubcommand {
     /// [experimental] Generate JSON Schema for the app server protocol.
     GenerateJsonSchema(GenerateJsonSchemaCommand),
 
-    /// [internal] Generate internal JSON Schema artifacts for Codex tooling.
+    /// [internal] Generate internal JSON Schema artifacts for application tooling.
     #[clap(hide = true)]
     GenerateInternalJsonSchema(GenerateInternalJsonSchemaCommand),
 }
@@ -1067,7 +1067,7 @@ fn api_key_login_help() -> String {
 
 fn access_token_login_help() -> String {
     format!(
-        "Read the access token from stdin (e.g. `printenv CODEX_ACCESS_TOKEN | {} login --with-access-token`)",
+        "Read the access token from stdin (pipe it into `{} login --with-access-token`)",
         product_command_name()
     )
 }
@@ -2021,7 +2021,9 @@ async fn load_exec_server_remote_auth_provider(
 ) -> anyhow::Result<codex_api::SharedAuthProvider> {
     if use_agent_identity_auth {
         read_codex_access_token_from_env().ok_or_else(|| {
-            anyhow::anyhow!("CODEX_ACCESS_TOKEN is required when --use-agent-identity-auth is set")
+            anyhow::anyhow!(
+                "an Agent Identity access token is required when --use-agent-identity-auth is set"
+            )
         })?;
         let auth = AuthManager::shared_from_config(config, /*enable_codex_api_key_env*/ false)
             .await?
@@ -2030,14 +2032,14 @@ async fn load_exec_server_remote_auth_provider(
             .ok_or_else(|| anyhow::anyhow!("Agent Identity authentication is unavailable"))?;
         if !matches!(auth, CodexAuth::AgentIdentity(_)) {
             anyhow::bail!(
-                "CODEX_ACCESS_TOKEN did not provide permitted Agent Identity authentication"
+                "the configured access token did not provide permitted Agent Identity authentication"
             );
         }
         return Ok(codex_model_provider::auth_provider_from_auth(&auth));
     }
 
     let auth = load_exec_server_remote_auth(config, &format!(
-        "remote exec-server registration requires ChatGPT authentication or API key authentication; run `{} login` or set CODEX_API_KEY",
+        "remote exec-server registration requires ChatGPT authentication or API key authentication; run `{} login` or set a compatible API key",
         product_command_name()
     ))
     .await?;

--- a/codex-rs/cli/tests/cloud_auth.rs
+++ b/codex-rs/cli/tests/cloud_auth.rs
@@ -85,7 +85,7 @@ async fn cloud_list_only_allows_trusted_credential_destinations() -> Result<()> 
         .args(["cloud", "list", "--limit", "1", "--json"])
         .assert()
         .failure()
-        .stderr(contains("Not signed in. Please run 'codex login'"));
+        .stderr(contains("Not signed in. Please run 'login'"));
     auth_server.verify().await;
     Ok(())
 }

--- a/codex-rs/cli/tests/cloud_auth.rs
+++ b/codex-rs/cli/tests/cloud_auth.rs
@@ -85,7 +85,35 @@ async fn cloud_list_only_allows_trusted_credential_destinations() -> Result<()> 
         .args(["cloud", "list", "--limit", "1", "--json"])
         .assert()
         .failure()
-        .stderr(contains("Not signed in. Please run 'login'"));
+        .stderr(contains(
+            "Not signed in. Please run 'codex login' to sign in with ChatGPT, then re-run 'codex cloud'.",
+        ));
     auth_server.verify().await;
+
+    let interpreter_home = TempDir::new()?;
+    let interpreter_auth_server = MockServer::start().await;
+    Mock::given(path("/v1/user-auth-credential/whoami"))
+        .and(header("authorization", "Bearer at-synthetic-cloud"))
+        .respond_with(ResponseTemplate::new(401))
+        .expect(1)
+        .mount(&interpreter_auth_server)
+        .await;
+    command()?
+        .env("OPEN_INTERPRETER_BRAND", "1")
+        .env("INTERPRETER_HOME", interpreter_home.path())
+        .env_remove("CODEX_HOME")
+        .env(
+            "CODEX_CLOUD_TASKS_BASE_URL",
+            "https://chatgpt-staging.com/backend-api",
+        )
+        .env("CODEX_ACCESS_TOKEN", "at-synthetic-cloud")
+        .env("CODEX_AUTHAPI_BASE_URL", interpreter_auth_server.uri())
+        .args(["cloud", "list", "--limit", "1", "--json"])
+        .assert()
+        .failure()
+        .stderr(contains(
+            "Not signed in. Please run 'interpreter login' to sign in with ChatGPT, then re-run 'interpreter cloud'.",
+        ));
+    interpreter_auth_server.verify().await;
     Ok(())
 }

--- a/codex-rs/cli/tests/product_identity.rs
+++ b/codex-rs/cli/tests/product_identity.rs
@@ -116,10 +116,25 @@ fn interpreter_help_version_errors_and_completions_keep_product_identity() -> an
     for shell in ["bash", "zsh", "fish", "powershell"] {
         let (stdout, stderr) = run(&interpreter, &["completion", shell], &envs, &[])?;
         assert_no_codex_brand(shell, &stdout, &stderr);
-        assert!(
-            stdout.to_ascii_lowercase().contains("interpreter"),
-            "{shell} completion should target interpreter: {stdout}"
-        );
+        match shell {
+            "bash" => assert!(
+                stdout.starts_with("_interpreter()"),
+                "bash completion should define _interpreter: {stdout}"
+            ),
+            "zsh" => assert!(
+                stdout.starts_with("#compdef interpreter"),
+                "zsh completion should target interpreter: {stdout}"
+            ),
+            "fish" => assert!(
+                stdout.contains("complete -c interpreter"),
+                "fish completion should target interpreter: {stdout}"
+            ),
+            "powershell" => assert!(
+                stdout.contains("interpreter"),
+                "PowerShell completion should target interpreter: {stdout}"
+            ),
+            _ => unreachable!("unsupported shell {shell}"),
+        }
         let chat_completions_option = if shell == "fish" {
             "chat-completions"
         } else {
@@ -130,6 +145,28 @@ fn interpreter_help_version_errors_and_completions_keep_product_identity() -> an
             "{shell} completion should include {chat_completions_option}: {stdout}"
         );
     }
+
+    let (stdout, stderr) = run(&interpreter, &["--help"], &envs, &[])?;
+    assert_no_codex_brand("root help examples", &stdout, &stderr);
+    assert!(
+        stdout.contains("interpreter completion bash"),
+        "root help should show completion generation: {stdout}"
+    );
+    assert!(
+        stdout.contains("interpreter --chat-completions"),
+        "root help should show Chat Completions usage: {stdout}"
+    );
+    assert!(
+        stdout.contains("Chat Completions API") && stdout.contains("Responses API"),
+        "root help should explain Chat Completions behavior: {stdout}"
+    );
+
+    let (stdout, stderr) = run(&interpreter, &["cloud", "--help"], &envs, &[])?;
+    assert_no_codex_brand("cloud help", &stdout, &stderr);
+    assert!(
+        stdout.contains("interpreter cloud"),
+        "cloud help should use the public product command: {stdout}"
+    );
     Ok(())
 }
 

--- a/codex-rs/cli/tests/product_identity.rs
+++ b/codex-rs/cli/tests/product_identity.rs
@@ -101,6 +101,12 @@ fn interpreter_help_version_errors_and_completions_keep_product_identity() -> an
             "invalid argument",
             &["--definitely-not-an-interpreter-option"][..],
         ),
+        (
+            "exec invalid argument",
+            &["exec", "--definitely-not-an-interpreter-option"][..],
+        ),
+        ("login help", &["login", "--help"][..]),
+        ("cloud help", &["cloud", "--help"][..]),
         ("debug update error", &["update"][..]),
     ] {
         let (stdout, stderr) = run(&interpreter, args, &envs, &[])?;
@@ -114,9 +120,14 @@ fn interpreter_help_version_errors_and_completions_keep_product_identity() -> an
             stdout.to_ascii_lowercase().contains("interpreter"),
             "{shell} completion should target interpreter: {stdout}"
         );
+        let chat_completions_option = if shell == "fish" {
+            "chat-completions"
+        } else {
+            "--chat-completions"
+        };
         assert!(
-            stdout.contains("--chat-completions"),
-            "{shell} completion should include --chat-completions: {stdout}"
+            stdout.contains(chat_completions_option),
+            "{shell} completion should include {chat_completions_option}: {stdout}"
         );
     }
     Ok(())

--- a/codex-rs/cloud-tasks/Cargo.toml
+++ b/codex-rs/cloud-tasks/Cargo.toml
@@ -24,6 +24,7 @@ codex-core = { workspace = true }
 codex-git-utils = { workspace = true }
 codex-login = { path = "../login" }
 codex-model-provider = { workspace = true }
+codex-product-info = { workspace = true }
 codex-tui = { workspace = true }
 codex-utils-cli = { workspace = true }
 crossterm = { workspace = true, features = ["event-stream"] }

--- a/codex-rs/cloud-tasks/src/cli.rs
+++ b/codex-rs/cloud-tasks/src/cli.rs
@@ -32,8 +32,11 @@ pub struct ExecCommand {
     #[arg(value_name = "QUERY")]
     pub query: Option<String>,
 
-    /// Target environment identifier (see `cloud` to browse).
-    #[arg(long = "env", value_name = "ENV_ID")]
+    #[arg(
+        long = "env",
+        value_name = "ENV_ID",
+        help = environment_help()
+    )]
     pub environment: String,
 
     /// Number of assistant attempts (best-of-N).
@@ -47,6 +50,11 @@ pub struct ExecCommand {
     /// Git branch to run in the hosted cloud service (defaults to current branch).
     #[arg(long = "branch", value_name = "BRANCH")]
     pub branch: Option<String>,
+}
+
+fn environment_help() -> String {
+    let command = crate::product_cloud_command();
+    format!("Target environment identifier (see `{command}` to browse).")
 }
 
 fn parse_attempts(input: &str) -> Result<usize, String> {

--- a/codex-rs/cloud-tasks/src/cli.rs
+++ b/codex-rs/cloud-tasks/src/cli.rs
@@ -14,25 +14,25 @@ pub struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
-    /// Submit a new Codex Cloud task without launching the TUI.
+    /// Submit a new hosted cloud task without launching the TUI.
     Exec(ExecCommand),
-    /// Show the status of a Codex Cloud task.
+    /// Show the status of a hosted cloud task.
     Status(StatusCommand),
-    /// List Codex Cloud tasks.
+    /// List hosted cloud tasks.
     List(ListCommand),
-    /// Apply the diff for a Codex Cloud task locally.
+    /// Apply the diff for a hosted cloud task locally.
     Apply(ApplyCommand),
-    /// Show the unified diff for a Codex Cloud task.
+    /// Show the unified diff for a hosted cloud task.
     Diff(DiffCommand),
 }
 
 #[derive(Debug, Args)]
 pub struct ExecCommand {
-    /// Task prompt to run in Codex Cloud.
+    /// Task prompt to run in the hosted cloud service.
     #[arg(value_name = "QUERY")]
     pub query: Option<String>,
 
-    /// Target environment identifier (see `codex cloud` to browse).
+    /// Target environment identifier (see `cloud` to browse).
     #[arg(long = "env", value_name = "ENV_ID")]
     pub environment: String,
 
@@ -44,7 +44,7 @@ pub struct ExecCommand {
     )]
     pub attempts: usize,
 
-    /// Git branch to run in Codex Cloud (defaults to current branch).
+    /// Git branch to run in the hosted cloud service (defaults to current branch).
     #[arg(long = "branch", value_name = "BRANCH")]
     pub branch: Option<String>,
 }
@@ -73,7 +73,7 @@ fn parse_limit(input: &str) -> Result<i64, String> {
 
 #[derive(Debug, Args)]
 pub struct StatusCommand {
-    /// Codex Cloud task identifier to inspect.
+    /// Hosted cloud task identifier to inspect.
     #[arg(value_name = "TASK_ID")]
     pub task_id: String,
 }
@@ -99,7 +99,7 @@ pub struct ListCommand {
 
 #[derive(Debug, Args)]
 pub struct ApplyCommand {
-    /// Codex Cloud task identifier to apply.
+    /// Hosted cloud task identifier to apply.
     #[arg(value_name = "TASK_ID")]
     pub task_id: String,
 
@@ -110,7 +110,7 @@ pub struct ApplyCommand {
 
 #[derive(Debug, Args)]
 pub struct DiffCommand {
-    /// Codex Cloud task identifier to display.
+    /// Hosted cloud task identifier to display.
     #[arg(value_name = "TASK_ID")]
     pub task_id: String,
 

--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -93,7 +93,7 @@ async fn init_backend(user_agent_suffix: &str) -> anyhow::Result<BackendContext>
         Some(auth) => auth,
         None => {
             eprintln!(
-                "Not signed in. Please run 'codex login' to sign in with ChatGPT, then re-run 'codex cloud'."
+                "Not signed in. Please run 'login' to sign in with ChatGPT, then re-run 'cloud'."
             );
             std::process::exit(1);
         }
@@ -105,7 +105,7 @@ async fn init_backend(user_agent_suffix: &str) -> anyhow::Result<BackendContext>
 
     if !auth.uses_codex_backend() {
         eprintln!(
-            "Not signed in. Please run 'codex login' to sign in with ChatGPT, then re-run 'codex cloud'."
+            "Not signed in. Please run 'login' to sign in with ChatGPT, then re-run 'cloud'."
         );
         std::process::exit(1);
     }
@@ -230,7 +230,7 @@ async fn resolve_environment_id(ctx: &BackendContext, requested: &str) -> anyhow
         .collect::<Vec<_>>();
     match label_matches.as_slice() {
         [] => Err(anyhow!(
-            "environment '{trimmed}' not found; run `codex cloud` to list available environments"
+            "environment '{trimmed}' not found; run `cloud` to list available environments"
         )),
         [single] => Ok(single.id.clone()),
         [first, rest @ ..] => {
@@ -239,7 +239,7 @@ async fn resolve_environment_id(ctx: &BackendContext, requested: &str) -> anyhow
                 Ok(first_id.clone())
             } else {
                 Err(anyhow!(
-                    "environment label '{trimmed}' is ambiguous; run `codex cloud` to pick the desired environment id"
+                    "environment label '{trimmed}' is ambiguous; run `cloud` to pick the desired environment id"
                 ))
             }
         }
@@ -582,7 +582,7 @@ async fn run_list_command(args: crate::cli::ListCommand) -> anyhow::Result<()> {
         println!("{line}");
     }
     if let Some(cursor) = page.cursor {
-        let command = format!("codex cloud list --cursor='{cursor}'");
+        let command = format!("cloud list --cursor='{cursor}'");
         if colorize {
             println!(
                 "\nTo fetch the next page, run {}",
@@ -749,7 +749,7 @@ fn spawn_apply(
 
 // (no standalone patch summarizer needed – UI displays raw diffs)
 
-/// Entry point for the `codex cloud` subcommand.
+/// Entry point for the `cloud` subcommand.
 pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()> {
     if let Some(command) = cli.command {
         return match command {

--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -17,6 +17,7 @@ use codex_http_client::HttpClientFactory;
 use codex_http_client::OutboundProxyPolicy;
 use codex_http_client::RouteAwareClientPool;
 use codex_login::default_client::get_codex_user_agent;
+use codex_product_info::Product;
 use owo_colors::OwoColorize;
 use owo_colors::Stream;
 use std::cmp::Ordering;
@@ -43,6 +44,11 @@ struct BackendContext {
     backend: Arc<dyn codex_cloud_tasks_client::CloudBackend>,
     base_url: String,
     environment_http: RouteAwareClientPool,
+}
+
+pub(crate) fn product_cloud_command() -> String {
+    let command = Product::current().command_name();
+    format!("{command} cloud")
 }
 
 async fn init_backend(user_agent_suffix: &str) -> anyhow::Result<BackendContext> {
@@ -92,8 +98,9 @@ async fn init_backend(user_agent_suffix: &str) -> anyhow::Result<BackendContext>
     let auth = match auth {
         Some(auth) => auth,
         None => {
+            let command_name = Product::current().command_name();
             eprintln!(
-                "Not signed in. Please run 'login' to sign in with ChatGPT, then re-run 'cloud'."
+                "Not signed in. Please run '{command_name} login' to sign in with ChatGPT, then re-run '{command_name} cloud'."
             );
             std::process::exit(1);
         }
@@ -104,8 +111,9 @@ async fn init_backend(user_agent_suffix: &str) -> anyhow::Result<BackendContext>
     }
 
     if !auth.uses_codex_backend() {
+        let command_name = Product::current().command_name();
         eprintln!(
-            "Not signed in. Please run 'login' to sign in with ChatGPT, then re-run 'cloud'."
+            "Not signed in. Please run '{command_name} login' to sign in with ChatGPT, then re-run '{command_name} cloud'."
         );
         std::process::exit(1);
     }
@@ -229,17 +237,21 @@ async fn resolve_environment_id(ctx: &BackendContext, requested: &str) -> anyhow
         })
         .collect::<Vec<_>>();
     match label_matches.as_slice() {
-        [] => Err(anyhow!(
-            "environment '{trimmed}' not found; run `cloud` to list available environments"
-        )),
+        [] => {
+            let command = product_cloud_command();
+            Err(anyhow!(
+                "environment '{trimmed}' not found; run `{command}` to list available environments"
+            ))
+        }
         [single] => Ok(single.id.clone()),
         [first, rest @ ..] => {
             let first_id = &first.id;
             if rest.iter().all(|row| row.id == *first_id) {
                 Ok(first_id.clone())
             } else {
+                let command = product_cloud_command();
                 Err(anyhow!(
-                    "environment label '{trimmed}' is ambiguous; run `cloud` to pick the desired environment id"
+                    "environment label '{trimmed}' is ambiguous; run `{command}` to pick the desired environment id"
                 ))
             }
         }
@@ -582,7 +594,8 @@ async fn run_list_command(args: crate::cli::ListCommand) -> anyhow::Result<()> {
         println!("{line}");
     }
     if let Some(cursor) = page.cursor {
-        let command = format!("cloud list --cursor='{cursor}'");
+        let product_command = product_cloud_command();
+        let command = format!("{product_command} list --cursor='{cursor}'");
         if colorize {
             println!(
                 "\nTo fetch the next page, run {}",

--- a/codex-rs/core/src/client_chat_transport_tests.rs
+++ b/codex-rs/core/src/client_chat_transport_tests.rs
@@ -270,7 +270,7 @@ async fn zcode_messages_turn_reaches_anthropic_transport() -> anyhow::Result<()>
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
-                .set_body_string(anthropic_text_sse("glm-5.3", "hello")),
+                .set_body_string(anthropic_text_sse("glm-5.2", "hello")),
         )
         .expect(/*requests*/ 1)
         .mount(&server)
@@ -278,7 +278,7 @@ async fn zcode_messages_turn_reaches_anthropic_transport() -> anyhow::Result<()>
 
     collect_stream_events(
         messages_model_client(&server.uri(), Harness::ZCode),
-        "glm-5.3",
+        "glm-5.2",
         user_prompt("hello"),
     )
     .await

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -36,7 +36,7 @@ pub struct Cli {
     #[arg(long = "ephemeral", global = true, default_value_t = false)]
     pub ephemeral: bool,
 
-    /// Do not load `$CODEX_HOME/config.toml`; auth still uses `CODEX_HOME`.
+    /// Do not load the user's config.toml; authentication is still loaded.
     #[arg(long = "ignore-user-config", global = true, default_value_t = false)]
     pub ignore_user_config: bool,
 

--- a/codex-rs/utils/cli/src/shared_options.rs
+++ b/codex-rs/utils/cli/src/shared_options.rs
@@ -22,8 +22,12 @@ pub struct SharedCliOptions {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
-    /// Use the selected provider's OpenAI-compatible Chat Completions API.
-    #[arg(long = "chat-completions", default_value_t = false)]
+    /// Use the selected provider's OpenAI-compatible Chat Completions API instead of Responses.
+    #[arg(
+        long = "chat-completions",
+        default_value_t = false,
+        long_help = chat_completions_help()
+    )]
     pub chat_completions: bool,
 
     /// Use open-source provider.
@@ -74,6 +78,13 @@ pub struct SharedCliOptions {
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
+}
+
+fn chat_completions_help() -> String {
+    let command = codex_product_info::Product::current().command_name();
+    format!(
+        "Use the selected provider's OpenAI-compatible Chat Completions API instead of the Responses API.\n\nExamples:\n  {command} --chat-completions\n  {command} exec --chat-completions \"summarize this repository\""
+    )
 }
 
 impl SharedCliOptions {

--- a/docs/models.md
+++ b/docs/models.md
@@ -35,7 +35,8 @@ active provider currently offers.
 | --- | --- | --- | --- |
 | Inherited upstream presets | Use only where the active provider exposes them | `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | Provider default |
 | Google AI Studio | Provider `google` and `GEMINI_API_KEY` | `gemini-3.8-flash`, `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite` | `chat` |
-| Z.AI | Provider `zai` or `zai-coding-plan` and `ZAI_API_KEY` | `glm-5.2`, `glm-5-turbo` | `chat` |
+| Anthropic | Provider `anthropic` and `ANTHROPIC_API_KEY` | `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5-20251001` | Provider default |
+| Z.AI | Provider `zai` or `zai-coding-plan` and `ZAI_API_KEY` | `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7-flash` | `chat` |
 
 The first row contains OpenAI-style choices inherited from the upstream
 `models-manager/models.json`; it is upstream preset metadata, not a guarantee
@@ -43,10 +44,11 @@ that every provider accepts those IDs. Google's current official [Gemini model
 list](https://ai.google.dev/gemini-api/docs/models) includes the listed stable
 Gemini 3 Flash text IDs and identifies `gemini-3.8-flash` as its most intelligent
 Flash model. Its [OpenAI compatibility guide](https://ai.google.dev/gemini-api/docs/openai)
-documents the compatible endpoint. For Z.AI, the [GLM-5.2 guide](https://docs.z.ai/guides/llm/glm-5.2)
+documents the compatible endpoint. For Z.AI, the [GLM-5.1 guide](https://docs.z.ai/guides/llm/glm-5.1)
 and [GLM-5-Turbo guide](https://docs.z.ai/guides/llm/glm-5-turbo) use the listed
 IDs; use the exact IDs returned for the selected service rather than guessing an
 alias.
+Anthropic's [model lifecycle page](https://platform.claude.com/docs/en/about-claude/model-deprecations) lists the shown Anthropic IDs as active.
 
 ## Where Model Metadata Comes From
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -23,6 +23,31 @@ model_reasoning_summary = "auto"
 model_verbosity = "medium"
 ```
 
+## Easy Verified Choices
+
+These are convenient starting points for common providers. The IDs below are
+either inherited from upstream model metadata or documented by the provider's
+current official sources. Availability still depends on the selected account,
+region, plan, and provider `/models` response. Use `/model` to discover what the
+active provider currently offers.
+
+| Provider | Setup | Text model IDs | Wire API |
+| --- | --- | --- | --- |
+| Inherited upstream presets | Use only where the active provider exposes them | `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | Provider default |
+| Google AI Studio | Provider `google` and `GEMINI_API_KEY` | `gemini-3.8-flash`, `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite` | `chat` |
+| Z.AI | Provider `zai` or `zai-coding-plan` and `ZAI_API_KEY` | `glm-5.2`, `glm-5-turbo` | `chat` |
+
+The first row contains OpenAI-style choices inherited from the upstream
+`models-manager/models.json`; it is upstream preset metadata, not a guarantee
+that every provider accepts those IDs. Google's current official [Gemini model
+list](https://ai.google.dev/gemini-api/docs/models) includes the listed stable
+Gemini 3 Flash text IDs and identifies `gemini-3.8-flash` as its most intelligent
+Flash model. Its [OpenAI compatibility guide](https://ai.google.dev/gemini-api/docs/openai)
+documents the compatible endpoint. For Z.AI, the [GLM-5.2 guide](https://docs.z.ai/guides/llm/glm-5.2)
+and [GLM-5-Turbo guide](https://docs.z.ai/guides/llm/glm-5-turbo) use the listed
+IDs; use the exact IDs returned for the selected service rather than guessing an
+alias.
+
 ## Where Model Metadata Comes From
 
 Open Interpreter does not keep one hand-written Rust list of every model.

--- a/docs/zai-glm.md
+++ b/docs/zai-glm.md
@@ -92,8 +92,9 @@ endpoint and plan-eligibility details.
 
 Use `/model` rather than maintaining a private list. The picker is generated
 from maintained provider sources and includes current GLM model IDs for the
-selected service. For example, the bundled Z.AI Coding Plan catalog currently
-includes `glm-5.2`, `glm-5.1`, `glm-5-turbo`, and lower-cost models.
+selected service. The provider-documented starting choices are `glm-5.2` and
+`glm-5-turbo`; use the exact IDs returned for the selected service rather than
+guessing a versioned alias.
 
 Z.AI may update server-side model mappings and plan eligibility independently
 of Open Interpreter. Check its [model-switching guide](https://docs.z.ai/devpack/using5.1)

--- a/docs/zai-glm.md
+++ b/docs/zai-glm.md
@@ -37,7 +37,7 @@ For a direct Z.AI Coding Plan launch:
 ```bash
 ZAI_API_KEY="..." interpreter \
   -c 'model_provider="zai-coding-plan"' \
-  -m glm-5.2
+  -m glm-5.1
 ```
 
 For the general Z.AI API, change the provider to `zai`. Users of the China
@@ -60,7 +60,7 @@ Z.AI officially provides an Anthropic-compatible Coding Plan endpoint at
 
 ```toml
 model_provider = "zai-zcode"
-model = "glm-5.2"
+model = "glm-5.1"
 harness = "zcode"
 
 [model_providers.zai-zcode]
@@ -92,9 +92,9 @@ endpoint and plan-eligibility details.
 
 Use `/model` rather than maintaining a private list. The picker is generated
 from maintained provider sources and includes current GLM model IDs for the
-selected service. The provider-documented starting choices are `glm-5.2` and
-`glm-5-turbo`; use the exact IDs returned for the selected service rather than
-guessing a versioned alias.
+selected service. The provider-documented starting choices are `glm-5.1`, `glm-5`,
+`glm-5-turbo`, and the free/lightweight `glm-4.7-flash`; use the exact IDs
+returned for the selected service rather than guessing a versioned alias.
 
 Z.AI may update server-side model mappings and plan eligibility independently
 of Open Interpreter. Check its [model-switching guide](https://docs.z.ai/devpack/using5.1)

--- a/docs/zh/models.md
+++ b/docs/zh/models.md
@@ -23,6 +23,18 @@ model_reasoning_summary = "auto"
 model_verbosity = "medium"
 ```
 
+## 易于验证的模型选择
+
+以下是常见提供商的便捷起点。下面的 ID 要么继承自上游模型元数据，要么记录在提供商当前的官方来源中。实际可用性仍取决于账户、地区、套餐以及提供商返回的 `/models` 列表。使用 `/model` 可查看当前活动提供商实际提供的模型。
+
+| 提供商 | 设置 | 文本模型 ID | Wire API |
+| --- | --- | --- | --- |
+| 上游继承的预设 | 仅在当前提供商提供这些 ID 时使用 | `gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` | 提供商默认值 |
+| Google AI Studio | 提供商 `google` 和 `GEMINI_API_KEY` | `gemini-3.8-flash`、`gemini-3.7-flash`、`gemini-3.6-flash`、`gemini-3.5-flash`、`gemini-3.5-flash-lite`、`gemini-3.1-flash-lite` | `chat` |
+| Z.AI | 提供商 `zai` 或 `zai-coding-plan` 和 `ZAI_API_KEY` | `glm-5.2`、`glm-5-turbo` | `chat` |
+
+第一行的 OpenAI 风格 ID 继承自上游的 `models-manager/models.json`，表示上游预设元数据，并不保证所有提供商都接受这些 ID。Google 当前的[官方 Gemini 模型列表](https://ai.google.dev/gemini-api/docs/models)包含所列的稳定 Gemini 3 Flash 文本 ID，并将 `gemini-3.8-flash` 列为其最智能的 Flash 模型。其[ OpenAI 兼容性指南](https://ai.google.dev/gemini-api/docs/openai)记录了兼容端点。对于 Z.AI，其 [GLM-5.2 指南](https://docs.z.ai/guides/llm/glm-5.2)和 [GLM-5-Turbo 指南](https://docs.z.ai/guides/llm/glm-5-turbo)使用上述 ID；请使用所选服务返回的准确 ID，不要猜测别名。
+
 ## 模型元数据的来源
 
 Open Interpreter 并未维护一份手写的 Rust 列表来列出所有模型。元数据分层如下：

--- a/docs/zh/models.md
+++ b/docs/zh/models.md
@@ -31,9 +31,10 @@ model_verbosity = "medium"
 | --- | --- | --- | --- |
 | 上游继承的预设 | 仅在当前提供商提供这些 ID 时使用 | `gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` | 提供商默认值 |
 | Google AI Studio | 提供商 `google` 和 `GEMINI_API_KEY` | `gemini-3.8-flash`、`gemini-3.7-flash`、`gemini-3.6-flash`、`gemini-3.5-flash`、`gemini-3.5-flash-lite`、`gemini-3.1-flash-lite` | `chat` |
-| Z.AI | 提供商 `zai` 或 `zai-coding-plan` 和 `ZAI_API_KEY` | `glm-5.2`、`glm-5-turbo` | `chat` |
+| Anthropic | 提供商 `anthropic` 和 `ANTHROPIC_API_KEY` | `claude-fable-5-1`、`claude-opus-5`、`claude-sonnet-5`、`claude-haiku-4-5-20251001` | 提供商默认值 |
+| Z.AI | 提供商 `zai` 或 `zai-coding-plan` 和 `ZAI_API_KEY` | `glm-5.1`、`glm-5`、`glm-5-turbo`、`glm-4.7-flash` | `chat` |
 
-第一行的 OpenAI 风格 ID 继承自上游的 `models-manager/models.json`，表示上游预设元数据，并不保证所有提供商都接受这些 ID。Google 当前的[官方 Gemini 模型列表](https://ai.google.dev/gemini-api/docs/models)包含所列的稳定 Gemini 3 Flash 文本 ID，并将 `gemini-3.8-flash` 列为其最智能的 Flash 模型。其[ OpenAI 兼容性指南](https://ai.google.dev/gemini-api/docs/openai)记录了兼容端点。对于 Z.AI，其 [GLM-5.2 指南](https://docs.z.ai/guides/llm/glm-5.2)和 [GLM-5-Turbo 指南](https://docs.z.ai/guides/llm/glm-5-turbo)使用上述 ID；请使用所选服务返回的准确 ID，不要猜测别名。
+第一行的 OpenAI 风格 ID 继承自上游的 `models-manager/models.json`，表示上游预设元数据，并不保证所有提供商都接受这些 ID。Google 当前的[官方 Gemini 模型列表](https://ai.google.dev/gemini-api/docs/models)包含所列的稳定 Gemini 3 Flash 文本 ID，并将 `gemini-3.8-flash` 列为其最智能的 Flash 模型。其[ OpenAI 兼容性指南](https://ai.google.dev/gemini-api/docs/openai)记录了兼容端点。对于 Z.AI，其 [GLM-5.1 指南](https://docs.z.ai/guides/llm/glm-5.1)和 [GLM-5-Turbo 指南](https://docs.z.ai/guides/llm/glm-5-turbo)使用上述 ID；请使用所选服务返回的准确 ID，不要猜测别名。
 
 ## 模型元数据的来源
 

--- a/docs/zh/zai-glm.md
+++ b/docs/zh/zai-glm.md
@@ -30,7 +30,7 @@ interpreter
 ```bash
 ZAI_API_KEY="..." interpreter \
   -c 'model_provider="zai-coding-plan"' \
-  -m glm-5.2
+  -m glm-5.1
 ```
 
 若使用通用 Z.AI API，将提供商改为 `zai`。使用中国区服务的用户应使用 `zhipuai` 或 `zhipuai-coding-plan` 并配合 `ZHIPU_API_KEY`。
@@ -45,7 +45,7 @@ Z.AI 官方提供了 Anthropic 兼容的 Coding Plan 端点，地址为 `https:/
 
 ```toml
 model_provider = "zai-zcode"
-model = "glm-5.2"
+model = "glm-5.1"
 harness = "zcode"
 
 [model_providers.zai-zcode]
@@ -70,7 +70,7 @@ Open Interpreter 会将 ZCode Messages 请求发送至 `/v1/messages`。额外�
 
 ## 选择 GLM 模型
 
-使用 `/model` 而不是维护私有列表。该选择器由维护的提供商来源生成，包含所选服务当前可用的 GLM 模型 ID。提供商文档中可作为起点的模型是 `glm-5.2` 和 `glm-5-turbo`；请使用所选服务返回的准确 ID，不要猜测版本别名。
+使用 `/model` 而不是维护私有列表。该选择器由维护的提供商来源生成，包含所选服务当前可用的 GLM 模型 ID。提供商文档中可作为起点的模型是 `glm-5.1`、`glm-5`、`glm-5-turbo` 和免费轻量级的 `glm-4.7-flash`；请使用所选服务返回的准确 ID，不要猜测版本别名。
 
 Z.AI 可能会在服务器端独立于 Open Interpreter 更新模型映射和计划资格。模型不可用或使用了不同配额倍率时，请查阅其[模型切换指南](https://docs.z.ai/devpack/using5.1)。
 

--- a/docs/zh/zai-glm.md
+++ b/docs/zh/zai-glm.md
@@ -70,7 +70,7 @@ Open Interpreter 会将 ZCode Messages 请求发送至 `/v1/messages`。额外�
 
 ## 选择 GLM 模型
 
-使用 `/model` 而不是维护私有列表。该选择器由维护的提供商来源生成，包含所选服务当前可用的 GLM 模型 ID。例如，捆绑的 Z.AI Coding Plan 目录目前包括 `glm-5.2`、`glm-5.1`、`glm-5-turbo` 以及更低成本的模型。
+使用 `/model` 而不是维护私有列表。该选择器由维护的提供商来源生成，包含所选服务当前可用的 GLM 模型 ID。提供商文档中可作为起点的模型是 `glm-5.2` 和 `glm-5-turbo`；请使用所选服务返回的准确 ID，不要猜测版本别名。
 
 Z.AI 可能会在服务器端独立于 Open Interpreter 更新模型映射和计划资格。模型不可用或使用了不同配额倍率时，请查阅其[模型切换指南](https://docs.z.ai/devpack/using5.1)。
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 set working-directory := "codex-rs"
-set positional-arguments := true
+set positional-arguments
 
 export CODEX_REPO_ROOT := justfile_directory()
 export JUST_SHELL := justfile_directory() / "scripts/just-shell.py"

--- a/scripts/build-interpreter-release.sh
+++ b/scripts/build-interpreter-release.sh
@@ -18,7 +18,7 @@ installs interpreter/i shims into the visible bin directory.
 EOF
 }
 
-repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 codex_rs_dir="$repo_root/codex-rs"
 target=""
 install_dir="${OPEN_INTERPRETER_INSTALL_DIR:-${CODEX_INSTALL_DIR:-$HOME/.local/bin}}"
@@ -126,6 +126,27 @@ echo "Cargo build jobs: $build_jobs"
 mkdir -p "$releases_dir" "$install_dir"
 rm -rf "$staging_dir"
 
+python_command="${OPEN_INTERPRETER_PYTHON:-}"
+if [[ -n "$python_command" ]]; then
+  if ! command -v "$python_command" >/dev/null 2>&1 ||
+     ! "$python_command" -c 'import tomllib' >/dev/null 2>&1; then
+    echo "OPEN_INTERPRETER_PYTHON must name a Python interpreter with tomllib support" >&2
+    exit 1
+  fi
+else
+  for candidate in python3 python3.13 python3.12 python3.11; do
+    if command -v "$candidate" >/dev/null 2>&1 &&
+       "$candidate" -c 'import tomllib' >/dev/null 2>&1; then
+      python_command="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$python_command" ]]; then
+    echo "Python 3.11 or newer is required to build the release package" >&2
+    exit 1
+  fi
+fi
+
 (
   cd "$repo_root"
   package_args=(
@@ -137,7 +158,9 @@ rm -rf "$staging_dir"
   if [[ -n "$target" ]]; then
     package_args=(--target "$target" "${package_args[@]}")
   fi
-  CARGO_BUILD_JOBS="$build_jobs" python3 scripts/build_codex_package.py "${package_args[@]}"
+  CODEX_REPO_ROOT="$repo_root" \
+    CARGO_BUILD_JOBS="$build_jobs" \
+    "$python_command" scripts/build_codex_package.py "${package_args[@]}"
 )
 
 if [[ -e "$package_dir" || -L "$package_dir" ]]; then

--- a/scripts/codex_package/smoke_tests/smoke_cli_archive.py
+++ b/scripts/codex_package/smoke_tests/smoke_cli_archive.py
@@ -59,9 +59,7 @@ def smoke_open_interpreter(root: Path, entrypoint: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--archive", type=Path, required=True)
-    parser.add_argument(
-        "--product", choices=("open-interpreter",), required=True
-    )
+    parser.add_argument("--product", choices=("open-interpreter",), required=True)
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory(prefix="cli-package-smoke-") as temp:

--- a/scripts/ollama_qwen_smoke.py
+++ b/scripts/ollama_qwen_smoke.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+"""Run a bounded CPU-only Ollama/Qwen tool-use smoke test.
+
+The harness is deliberately self-contained: it can use an existing Ollama
+server and model cache, or install and start a user-local Ollama binary. It
+records the exact command, bounded output, and on-disk result so a successful
+assistant message cannot be mistaken for a successful file operation.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import time
+from typing import Any, Iterable, Sequence
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_MODEL = "qwen2.5-coder:1.5b"
+VERIFIED_QWEN_MODELS = (DEFAULT_MODEL, "qwen2.5-coder:7b")
+DEFAULT_OLLAMA_VERSION = "0.13.4"
+DEFAULT_HOST = "127.0.0.1:11434"
+DEFAULT_CONTEXT_LENGTH = 32768
+DEFAULT_STARTUP_TIMEOUT_SECONDS = 180
+DEFAULT_PULL_TIMEOUT_SECONDS = 7200
+DEFAULT_RUN_TIMEOUT_SECONDS = 3600
+DEFAULT_MAX_TRACE_BYTES = 10 * 1024 * 1024
+DEFAULT_MAX_LOG_BYTES = 2 * 1024 * 1024
+DEFAULT_EXPECTED_FILE = "oix-ollama-smoke.txt"
+DEFAULT_EXPECTED_CONTENT = "open-interpreter ollama qwen smoke\n"
+
+
+class HarnessError(RuntimeError):
+    """An expected setup or execution failure in the smoke harness."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int | None
+    timed_out: bool
+    output: bytes
+    total_bytes: int
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class SideEffectResult:
+    verified: bool
+    path: str
+    reason: str
+
+
+class BoundedCapture:
+    """Retain a bounded trace prefix while continuing to drain the process."""
+
+    def __init__(self, max_bytes: int) -> None:
+        if max_bytes < 128:
+            raise ValueError("max_bytes must be at least 128")
+        self.max_bytes = max_bytes
+        self.total_bytes = 0
+        self._data = bytearray()
+        self.truncated = False
+
+    def add(self, chunk: bytes) -> None:
+        self.total_bytes += len(chunk)
+        available = self.max_bytes - len(self._data)
+        if available > 0:
+            self._data.extend(chunk[:available])
+        if len(chunk) > available:
+            self.truncated = True
+
+    def data(self) -> bytes:
+        if not self.truncated:
+            return bytes(self._data)
+
+        omitted = self.total_bytes - self.max_bytes
+        marker = f"\n... {omitted} bytes omitted from bounded trace ...\n".encode()
+        return bytes(self._data[: self.max_bytes - len(marker)]) + marker
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    else:
+        process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+        else:
+            process.kill()
+        process.wait()
+
+
+def run_bounded_command(
+    args: Sequence[str],
+    *,
+    timeout_seconds: float,
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    max_bytes: int = DEFAULT_MAX_LOG_BYTES,
+) -> CommandResult:
+    """Run a command while draining and bounding combined stdout/stderr."""
+
+    process = subprocess.Popen(
+        list(args),
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=os.name == "posix",
+    )
+    assert process.stdout is not None
+    capture = BoundedCapture(max_bytes)
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+
+    try:
+        while True:
+            if not timed_out and time.monotonic() >= deadline:
+                timed_out = True
+                _terminate_process(process)
+
+            ready, _, _ = select.select([process.stdout], [], [], 0.1)
+            if ready:
+                # `BufferedReader.read()` may wait for its requested size or
+                # EOF even after select says that a smaller amount is ready.
+                # Read directly from the descriptor so sparse output cannot
+                # hold the deadline loop hostage.
+                chunk = os.read(process.stdout.fileno(), 65536)
+                if chunk:
+                    capture.add(chunk)
+                else:
+                    process.stdout.close()
+                    break
+            elif process.poll() is not None:
+                # A descendant can keep the pipe open after the leader exits.
+                # Treat that as a leaked command tree and terminate its group.
+                _terminate_process(process)
+                break
+    finally:
+        if process.poll() is None:
+            _terminate_process(process)
+        process.wait()
+        process.stdout.close()
+
+    return CommandResult(
+        returncode=process.returncode,
+        timed_out=timed_out,
+        output=capture.data(),
+        total_bytes=capture.total_bytes,
+        truncated=capture.truncated,
+    )
+
+
+def normalize_host(host: str) -> str:
+    value = host.strip().rstrip("/")
+    if not value:
+        raise ValueError("Ollama host must not be empty")
+    if "://" not in value:
+        value = f"http://{value}"
+    return value
+
+
+def ollama_is_ready(host: str, timeout_seconds: float = 2) -> bool:
+    try:
+        request = Request(f"{normalize_host(host)}/api/version")
+        with urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.load(response)
+    except (OSError, URLError, ValueError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and isinstance(payload.get("version"), str)
+
+
+def parse_ollama_list(output: str) -> dict[str, str | None]:
+    models: dict[str, str | None] = {}
+    for line in output.splitlines():
+        fields = line.split()
+        if not fields or fields[0].upper() == "NAME":
+            continue
+        models[fields[0]] = fields[1] if len(fields) > 1 else None
+    return models
+
+
+def select_model(requested: str | None, installed: Iterable[str]) -> str:
+    if requested:
+        if not requested.lower().startswith("qwen"):
+            raise ValueError(f"model must be a Qwen model: {requested}")
+        return requested
+
+    installed_set = set(installed)
+    for model in VERIFIED_QWEN_MODELS:
+        if model in installed_set:
+            return model
+    return DEFAULT_MODEL
+
+
+def validate_relative_file(value: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts:
+        raise ValueError("expected file must be a non-empty path inside the workspace")
+    return path.as_posix()
+
+
+def build_prompt(
+    user_prompt: str | None, expected_file: str, expected_content: str
+) -> str:
+    task = (
+        user_prompt
+        or "Perform a direct file-write smoke test in the current workspace."
+    )
+    return (
+        f"{task}\n\n"
+        "Required observable check: use the available file tool to create the file "
+        f"`{expected_file}` in the current workspace. Write exactly this UTF-8 "
+        f"content, including the final newline:\n{expected_content}"
+        "Do not merely describe the action; perform it before finishing."
+    )
+
+
+def build_interpreter_command(
+    interpreter: Path,
+    workspace: Path,
+    model: str,
+    prompt: str,
+) -> list[str]:
+    return [
+        str(interpreter),
+        "exec",
+        "--json",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--cd",
+        str(workspace),
+        "--oss",
+        "--local-provider",
+        "ollama",
+        "--chat-completions",
+        "--model",
+        model,
+        "--sandbox",
+        "workspace-write",
+        prompt,
+    ]
+
+
+TOOL_EVENT_TYPES = {
+    "command_execution",
+    "custom_tool_call",
+    "file_change",
+    "function_call",
+    "mcp_tool_call",
+    "tool_call",
+    "tool_use",
+}
+TOOL_KEYS = {
+    "command_execution",
+    "custom_tool_call",
+    "file_change",
+    "function_call",
+    "mcp_tool_call",
+    "tool_call",
+    "tool_name",
+    "toolName",
+    "tool_use",
+}
+
+
+def _tool_signals(value: Any, signals: list[str]) -> None:
+    if isinstance(value, dict):
+        event_type = str(value.get("type", "")).lower()
+        if event_type in TOOL_EVENT_TYPES:
+            signals.append(event_type)
+        for key, child in value.items():
+            if key in TOOL_KEYS and child not in (None, "", [], {}):
+                signals.append(key)
+            if key == "tool_calls" and isinstance(child, list):
+                signals.extend("tool_calls" for _ in child)
+            _tool_signals(child, signals)
+    elif isinstance(value, list):
+        for item in value:
+            _tool_signals(item, signals)
+
+
+def detect_tool_calls(trace: str) -> list[str]:
+    signals: list[str] = []
+    for line in trace.splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        _tool_signals(value, signals)
+    return signals
+
+
+CRASH_MARKERS = (
+    "panicked at",
+    "segmentation fault",
+    "sigsegv",
+    "abort trap",
+    "fatal runtime error",
+)
+
+
+def classify_attempt(
+    *,
+    returncode: int | None,
+    timed_out: bool,
+    trace: str,
+    side_effect: SideEffectResult,
+) -> str:
+    if timed_out:
+        return "interpreter_loop"
+    if (
+        returncode is None
+        or returncode < 0
+        or any(marker in trace.lower() for marker in CRASH_MARKERS)
+    ):
+        return "interpreter_crash"
+    if returncode != 0:
+        return "interpreter_failure"
+    if not detect_tool_calls(trace):
+        return "model_incompatible_no_tool_call"
+    if not side_effect.verified:
+        return "tool_call_without_requested_side_effect"
+    return "passed"
+
+
+def verify_side_effect(
+    workspace: Path, expected_file: str, expected_content: str
+) -> SideEffectResult:
+    path = workspace / expected_file
+    relative = Path(expected_file).as_posix()
+    if not path.is_file():
+        return SideEffectResult(False, relative, "file_missing")
+    actual = path.read_bytes()
+    if actual != expected_content.encode():
+        return SideEffectResult(False, relative, "content_mismatch")
+    return SideEffectResult(True, relative, "exact_content_match")
+
+
+def cpu_only_environment(
+    base: dict[str, str], *, host: str, models_dir: Path, context_length: int
+) -> dict[str, str]:
+    env = dict(base)
+    ollama_host = host.removeprefix("http://").removeprefix("https://")
+    env.update(
+        {
+            "OLLAMA_HOST": ollama_host,
+            "OLLAMA_MODELS": str(models_dir),
+            "OLLAMA_CONTEXT_LENGTH": str(context_length),
+            "CUDA_VISIBLE_DEVICES": "",
+            "ROCR_VISIBLE_DEVICES": "",
+        }
+    )
+    return env
+
+
+def _default_cache_dir() -> Path:
+    root = os.environ.get("XDG_CACHE_HOME")
+    return (
+        Path(root) / "open-interpreter" / "ollama"
+        if root
+        else Path.home() / ".cache" / "open-interpreter" / "ollama"
+    )
+
+
+def _ollama_archive_name() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "ollama-linux-amd64.tgz"
+    if machine in {"aarch64", "arm64"}:
+        return "ollama-linux-arm64.tgz"
+    raise HarnessError(f"unsupported Linux architecture for Ollama: {machine}")
+
+
+def find_or_install_ollama(
+    *,
+    explicit: str | None,
+    version: str,
+    cache_dir: Path,
+) -> Path:
+    candidates = [explicit] if explicit else []
+    if not explicit:
+        found = shutil.which("ollama")
+        if found:
+            candidates.append(found)
+        candidates.append(str(cache_dir / "ollama" / version / "bin" / "ollama"))
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK):
+            return Path(candidate).resolve()
+    install_dir = cache_dir / "ollama" / version
+    binary = install_dir / "bin" / "ollama"
+    if not binary.exists():
+        install_dir.mkdir(parents=True, exist_ok=True)
+        archive = install_dir / _ollama_archive_name()
+        url = (
+            "https://github.com/ollama/ollama/releases/download/"
+            f"v{version}/{archive.name}"
+        )
+        try:
+            with urlopen(url, timeout=60) as response, archive.open("wb") as output:
+                shutil.copyfileobj(response, output)
+        except (OSError, URLError) as error:
+            raise HarnessError(
+                f"failed to download Ollama from {url}: {error}"
+            ) from error
+        with tarfile.open(archive, "r:gz") as tar:
+            root = install_dir.resolve()
+            for member in tar.getmembers():
+                target = (install_dir / member.name).resolve()
+                if target != root and root not in target.parents:
+                    raise HarnessError(f"unsafe path in Ollama archive: {member.name}")
+            tar.extractall(install_dir)
+    if not binary.is_file():
+        raise HarnessError(f"Ollama archive did not provide {binary}")
+    binary.chmod(binary.stat().st_mode | 0o111)
+    return binary.resolve()
+
+
+def _start_ollama(
+    ollama: Path,
+    *,
+    env: dict[str, str],
+    startup_timeout: float,
+) -> subprocess.Popen[bytes]:
+    process = subprocess.Popen(
+        [str(ollama), "serve"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        start_new_session=os.name == "posix",
+    )
+    deadline = time.monotonic() + startup_timeout
+    while time.monotonic() < deadline:
+        if ollama_is_ready(env["OLLAMA_HOST"]):
+            return process
+        if process.poll() is not None:
+            raise HarnessError(
+                f"Ollama exited before becoming ready (exit {process.returncode})"
+            )
+        time.sleep(1)
+    _terminate_process(process)
+    raise HarnessError(f"Ollama did not become ready within {startup_timeout:g}s")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _run_attempt(
+    *,
+    attempt: int,
+    root: Path,
+    interpreter: Path,
+    model: str,
+    host: str,
+    prompt: str,
+    expected_file: str,
+    expected_content: str,
+    env: dict[str, str],
+    timeout_seconds: float,
+    max_trace_bytes: int,
+) -> dict[str, Any]:
+    attempt_root = root / f"attempt-{attempt}"
+    workspace = attempt_root / "workspace"
+    home = attempt_root / "interpreter-home"
+    attempt_root.mkdir()
+    workspace.mkdir()
+    home.mkdir()
+    (workspace / "src").mkdir()
+    (workspace / "README.md").write_text(
+        "# Ollama/Qwen smoke fixture\n\nThis file is intentionally small.\n",
+        encoding="utf-8",
+    )
+    (workspace / "src" / "main.py").write_text(
+        'def greeting(name: str) -> str:\n    return f"hello {name}"\n',
+        encoding="utf-8",
+    )
+    command = build_interpreter_command(interpreter, workspace, model, prompt)
+    attempt_env = dict(env)
+    attempt_env.update(
+        {
+            "CODEX_OSS_BASE_URL": f"{normalize_host(host)}/v1",
+            "INTERPRETER_HOME": str(home),
+            "CODEX_HOME": str(home),
+        }
+    )
+    result = run_bounded_command(
+        command,
+        timeout_seconds=timeout_seconds,
+        env=attempt_env,
+        cwd=workspace,
+        max_bytes=max_trace_bytes,
+    )
+    (attempt_root / "interpreter-trace.jsonl").write_bytes(result.output)
+    side_effect = verify_side_effect(workspace, expected_file, expected_content)
+    trace = result.output.decode("utf-8", errors="replace")
+    status = classify_attempt(
+        returncode=result.returncode,
+        timed_out=result.timed_out,
+        trace=trace,
+        side_effect=side_effect,
+    )
+    attempt_result = {
+        "attempt": attempt,
+        "status": status,
+        "returncode": result.returncode,
+        "timedOut": result.timed_out,
+        "toolCallCount": len(detect_tool_calls(trace)),
+        "traceBytes": result.total_bytes,
+        "traceTruncated": result.truncated,
+        "sideEffect": asdict(side_effect),
+    }
+    _write_json(attempt_root / "result.json", attempt_result)
+    return attempt_result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded Linux CPU-only Ollama/Qwen tool-use smoke test."
+    )
+    parser.add_argument(
+        "--interpreter", help="path to interpreter (default: PATH lookup)"
+    )
+    parser.add_argument("--model", help=f"Qwen model (default: {DEFAULT_MODEL})")
+    parser.add_argument("--ollama-version", default=DEFAULT_OLLAMA_VERSION)
+    parser.add_argument("--ollama", help="path to an Ollama binary")
+    parser.add_argument("--host", default=os.environ.get("OLLAMA_HOST", DEFAULT_HOST))
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path(os.environ["OIX_OLLAMA_CACHE"])
+        if os.environ.get("OIX_OLLAMA_CACHE")
+        else _default_cache_dir(),
+        help="durable cache for Ollama binaries and models",
+    )
+    parser.add_argument("--output-dir", type=Path, help="artifact directory")
+    parser.add_argument("--attempts", type=int, default=1)
+    parser.add_argument(
+        "--startup-timeout", type=float, default=DEFAULT_STARTUP_TIMEOUT_SECONDS
+    )
+    parser.add_argument(
+        "--pull-timeout", type=float, default=DEFAULT_PULL_TIMEOUT_SECONDS
+    )
+    parser.add_argument(
+        "--run-timeout", type=float, default=DEFAULT_RUN_TIMEOUT_SECONDS
+    )
+    parser.add_argument("--max-trace-bytes", type=int, default=DEFAULT_MAX_TRACE_BYTES)
+    parser.add_argument(
+        "--prompt", help="additional task text before the required file write"
+    )
+    parser.add_argument("--expected-file", default=DEFAULT_EXPECTED_FILE)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if platform.system() != "Linux":
+        print("This harness supports Linux only.", file=sys.stderr)
+        return 2
+    try:
+        for name in (
+            "attempts",
+            "startup_timeout",
+            "pull_timeout",
+            "run_timeout",
+            "max_trace_bytes",
+        ):
+            if getattr(args, name) <= 0:
+                raise HarnessError(f"{name} must be positive")
+        if not 1 <= args.attempts <= 5:
+            raise HarnessError("attempts must be between 1 and 5")
+        expected_file = validate_relative_file(args.expected_file)
+        root = args.output_dir or Path.cwd() / f"ollama-qwen-smoke-{int(time.time())}"
+        root = root.expanduser().resolve()
+        if root.exists() and any(root.iterdir()):
+            raise HarnessError(f"artifact directory is not empty: {root}")
+        root.mkdir(parents=True, exist_ok=False)
+        cache_dir = args.cache_dir.expanduser().resolve()
+        models_dir = Path(os.environ.get("OLLAMA_MODELS", cache_dir / "models"))
+        host = normalize_host(args.host)
+        base_env = cpu_only_environment(
+            os.environ,
+            host=host,
+            models_dir=models_dir,
+            context_length=DEFAULT_CONTEXT_LENGTH,
+        )
+
+        ollama = find_or_install_ollama(
+            explicit=args.ollama,
+            version=args.ollama_version,
+            cache_dir=cache_dir,
+        )
+        version_result = run_bounded_command(
+            [str(ollama), "--version"], timeout_seconds=30, env=base_env
+        )
+        (root / "ollama-version.txt").write_bytes(version_result.output)
+        if version_result.returncode != 0:
+            raise HarnessError("Ollama --version failed")
+
+        server_process: subprocess.Popen[bytes] | None = None
+        reused_server = ollama_is_ready(host)
+        if not reused_server:
+            server_process = _start_ollama(
+                ollama,
+                env=base_env,
+                startup_timeout=args.startup_timeout,
+            )
+        try:
+            list_result = run_bounded_command(
+                [str(ollama), "list"], timeout_seconds=60, env=base_env
+            )
+            (root / "ollama-list.txt").write_bytes(list_result.output)
+            installed = parse_ollama_list(
+                list_result.output.decode("utf-8", errors="replace")
+            )
+            model = select_model(args.model, installed)
+            if model not in installed:
+                pull_result = run_bounded_command(
+                    [str(ollama), "pull", model],
+                    timeout_seconds=args.pull_timeout,
+                    env=base_env,
+                    max_bytes=DEFAULT_MAX_LOG_BYTES,
+                )
+                (root / "ollama-pull.log").write_bytes(pull_result.output)
+                if pull_result.timed_out or pull_result.returncode != 0:
+                    raise HarnessError(f"failed to pull model {model}")
+                list_result = run_bounded_command(
+                    [str(ollama), "list"], timeout_seconds=60, env=base_env
+                )
+                (root / "ollama-list-after-pull.txt").write_bytes(list_result.output)
+                installed = parse_ollama_list(
+                    list_result.output.decode("utf-8", errors="replace")
+                )
+            if model not in installed:
+                raise HarnessError(f"Ollama does not list pulled model {model}")
+            prompt = build_prompt(args.prompt, expected_file, DEFAULT_EXPECTED_CONTENT)
+            interpreter_value = (
+                args.interpreter
+                or os.environ.get("INTERPRETER_BIN")
+                or shutil.which("interpreter")
+            )
+            if not interpreter_value:
+                raise HarnessError("interpreter was not found; pass --interpreter")
+            interpreter = Path(interpreter_value).expanduser().resolve()
+            if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+                raise HarnessError(f"interpreter is not executable: {interpreter}")
+            attempts = [
+                _run_attempt(
+                    attempt=attempt,
+                    root=root,
+                    interpreter=interpreter,
+                    model=model,
+                    host=host,
+                    prompt=prompt,
+                    expected_file=expected_file,
+                    expected_content=DEFAULT_EXPECTED_CONTENT,
+                    env=base_env,
+                    timeout_seconds=args.run_timeout,
+                    max_trace_bytes=args.max_trace_bytes,
+                )
+                for attempt in range(1, args.attempts + 1)
+            ]
+            model_digest = installed.get(model)
+            summary = {
+                "schemaVersion": 1,
+                "status": "passed"
+                if all(item["status"] == "passed" for item in attempts)
+                else "failed",
+                "model": model,
+                "modelDigest": model_digest,
+                "ollamaVersion": version_result.output.decode(
+                    "utf-8", errors="replace"
+                ).strip(),
+                "endpoint": f"{host}/v1",
+                "wireApi": "chat_completions",
+                "provider": "ollama",
+                "cpuOnly": True,
+                "serverReused": reused_server,
+                "cacheDir": str(cache_dir),
+                "modelsDir": str(models_dir),
+                "contextLength": DEFAULT_CONTEXT_LENGTH,
+                "timeouts": {
+                    "startup": args.startup_timeout,
+                    "pull": args.pull_timeout,
+                    "run": args.run_timeout,
+                },
+                "attempts": attempts,
+            }
+            _write_json(root / "summary.json", summary)
+            return 0 if summary["status"] == "passed" else 1
+        finally:
+            if server_process is not None:
+                _terminate_process(server_process)
+    except (HarnessError, OSError, ValueError) as error:
+        print(f"ollama/qwen smoke harness failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_build_interpreter_release.py
+++ b/scripts/test_build_interpreter_release.py
@@ -25,7 +25,11 @@ class BuildInterpreterReleaseTest(unittest.TestCase):
                 """\
                 #!/usr/bin/env bash
                 set -euo pipefail
+                if [[ "${1:-}" == "-c" ]]; then
+                  exit 0
+                fi
                 printf 'jobs=%s\\n' "${CARGO_BUILD_JOBS:-}" > "$TEST_INVOCATION"
+                printf 'repo_root=%s\\n' "${CODEX_REPO_ROOT:-}" >> "$TEST_INVOCATION"
                 printf '%s\\n' "$@" >> "$TEST_INVOCATION"
                 package_dir=""
                 while [[ $# -gt 0 ]]; do
@@ -85,6 +89,20 @@ class BuildInterpreterReleaseTest(unittest.TestCase):
         self.assertIn("--cargo-profile\nrelease\n", invocation)
         self.assertTrue((self.root / "visible-bin" / "interpreter").is_symlink())
         self.assertTrue((self.root / "visible-bin" / "i").is_symlink())
+
+    def test_builder_receives_script_repository_root_from_other_cwd(self) -> None:
+        result = self.run_script(
+            "--install-dir",
+            "visible-bin",
+            "--home",
+            "interpreter-home",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            f"repo_root={REPO_ROOT}\n",
+            self.invocation.read_text(encoding="utf-8"),
+        )
 
     def test_default_jobs_remains_one(self) -> None:
         result = self.run_script(

--- a/scripts/test_ollama_qwen_smoke.py
+++ b/scripts/test_ollama_qwen_smoke.py
@@ -1,0 +1,170 @@
+import os
+import sys
+from pathlib import Path
+import tempfile
+import time
+import unittest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ollama_qwen_smoke as smoke  # noqa: E402
+
+
+class OllamaQwenSmokeTest(unittest.TestCase):
+    def test_select_model_prefers_verified_cached_model(self) -> None:
+        self.assertEqual(
+            smoke.select_model(None, ["qwen2.5-coder:7b"]), "qwen2.5-coder:7b"
+        )
+        self.assertEqual(smoke.select_model(None, []), smoke.DEFAULT_MODEL)
+        with self.assertRaisesRegex(ValueError, "Qwen"):
+            smoke.select_model("llama3.2:1b", [])
+
+    def test_interpreter_command_selects_chat_completions(self) -> None:
+        command = smoke.build_interpreter_command(
+            Path("interpreter"), Path("workspace"), smoke.DEFAULT_MODEL, "do the task"
+        )
+
+        self.assertIn("--chat-completions", command)
+
+    def test_command_runner_drains_output_without_exceeding_bound(self) -> None:
+        result = smoke.run_bounded_command(
+            [sys.executable, "-c", "print('x' * 1000)"],
+            timeout_seconds=10,
+            max_bytes=128,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(result.truncated)
+        self.assertLessEqual(len(result.output), 128)
+
+    @unittest.skipUnless(os.name == "posix", "process-group semantics are POSIX-specific")
+    def test_command_runner_times_out_sparse_output_and_cleans_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            descendant_pid_path = Path(directory) / "descendant.pid"
+            child = (
+                "import pathlib, subprocess, sys, time\n"
+                "descendant = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+                "pathlib.Path(sys.argv[1]).write_text(str(descendant.pid), encoding='ascii')\n"
+                "print('prefix', end='', flush=True)\n"
+                "time.sleep(30)\n"
+            )
+            started = time.monotonic()
+            result = smoke.run_bounded_command(
+                [sys.executable, "-c", child, str(descendant_pid_path)],
+                timeout_seconds=0.2,
+                max_bytes=128,
+            )
+            elapsed = time.monotonic() - started
+
+            self.assertTrue(result.timed_out)
+            self.assertLess(elapsed, 2)
+            self.assertEqual(result.output, b"prefix")
+            self.assertEqual(result.total_bytes, len(result.output))
+            self.assertFalse(result.truncated)
+
+            descendant_pid = int(descendant_pid_path.read_text(encoding="ascii"))
+            process_deadline = time.monotonic() + 2
+            while time.monotonic() < process_deadline:
+                try:
+                    os.kill(descendant_pid, 0)
+                except ProcessLookupError:
+                    break
+                if sys.platform == "linux":
+                    proc_stat = Path(f"/proc/{descendant_pid}/stat")
+                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
+                        break
+                time.sleep(0.01)
+            else:
+                self.fail("timed-out command descendant survived process-group cleanup")
+
+            side_effect = smoke.SideEffectResult(False, "result.txt", "file_missing")
+            self.assertEqual(
+                smoke.classify_attempt(
+                    returncode=result.returncode,
+                    timed_out=result.timed_out,
+                    trace=result.output.decode("utf-8"),
+                    side_effect=side_effect,
+                ),
+                "interpreter_loop",
+            )
+
+    @unittest.skipUnless(os.name == "posix", "process-group semantics are POSIX-specific")
+    def test_command_runner_cleans_descendant_after_leader_exits(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            descendant_pid_path = Path(directory) / "descendant.pid"
+            child = (
+                "import pathlib, subprocess, sys, time\n"
+                "descendant = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+                "pathlib.Path(sys.argv[1]).write_text(str(descendant.pid), encoding='ascii')\n"
+                "print('prefix', end='', flush=True)\n"
+            )
+            result = smoke.run_bounded_command(
+                [sys.executable, "-c", child, str(descendant_pid_path)],
+                timeout_seconds=2,
+                max_bytes=128,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertFalse(result.timed_out)
+            self.assertEqual(result.output, b"prefix")
+            descendant_pid = int(descendant_pid_path.read_text(encoding="ascii"))
+            process_deadline = time.monotonic() + 2
+            while time.monotonic() < process_deadline:
+                try:
+                    os.kill(descendant_pid, 0)
+                except ProcessLookupError:
+                    break
+                if sys.platform == "linux":
+                    proc_stat = Path(f"/proc/{descendant_pid}/stat")
+                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
+                        break
+                time.sleep(0.01)
+            else:
+                self.fail("descendant survived cleanup after its process-group leader exited")
+
+    def test_side_effect_requires_exact_content(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            expected = smoke.verify_side_effect(workspace, "result.txt", "expected\n")
+            self.assertEqual(expected.reason, "file_missing")
+
+            (workspace / "result.txt").write_text("wrong\n", encoding="utf-8")
+            mismatch = smoke.verify_side_effect(workspace, "result.txt", "expected\n")
+            self.assertEqual(mismatch.reason, "content_mismatch")
+
+            (workspace / "result.txt").write_text("expected\n", encoding="utf-8")
+            verified = smoke.verify_side_effect(workspace, "result.txt", "expected\n")
+            self.assertTrue(verified.verified)
+
+    def test_classification_separates_model_and_interpreter_failures(self) -> None:
+        missing = smoke.SideEffectResult(False, "result.txt", "file_missing")
+        verified = smoke.SideEffectResult(True, "result.txt", "exact_content_match")
+        cases = (
+            (
+                "model_incompatible_no_tool_call",
+                0,
+                False,
+                '{"type":"message"}',
+                missing,
+            ),
+            ("interpreter_loop", None, True, '{"type":"command_execution"}', missing),
+            ("interpreter_crash", -11, False, "", missing),
+            ("passed", 0, False, '{"type":"function_call"}', verified),
+        )
+        for expected, returncode, timed_out, trace, side_effect in cases:
+            with self.subTest(expected=expected):
+                self.assertEqual(
+                    smoke.classify_attempt(
+                        returncode=returncode,
+                        timed_out=timed_out,
+                        trace=trace,
+                        side_effect=side_effect,
+                    ),
+                    expected,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ollama_qwen_smoke.py
+++ b/scripts/test_ollama_qwen_smoke.py
@@ -39,8 +39,12 @@ class OllamaQwenSmokeTest(unittest.TestCase):
         self.assertTrue(result.truncated)
         self.assertLessEqual(len(result.output), 128)
 
-    @unittest.skipUnless(os.name == "posix", "process-group semantics are POSIX-specific")
-    def test_command_runner_times_out_sparse_output_and_cleans_process_group(self) -> None:
+    @unittest.skipUnless(
+        os.name == "posix", "process-group semantics are POSIX-specific"
+    )
+    def test_command_runner_times_out_sparse_output_and_cleans_process_group(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             descendant_pid_path = Path(directory) / "descendant.pid"
             child = (
@@ -90,7 +94,9 @@ class OllamaQwenSmokeTest(unittest.TestCase):
                 "interpreter_loop",
             )
 
-    @unittest.skipUnless(os.name == "posix", "process-group semantics are POSIX-specific")
+    @unittest.skipUnless(
+        os.name == "posix", "process-group semantics are POSIX-specific"
+    )
     def test_command_runner_cleans_descendant_after_leader_exits(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             descendant_pid_path = Path(directory) / "descendant.pid"
@@ -122,7 +128,9 @@ class OllamaQwenSmokeTest(unittest.TestCase):
                         break
                 time.sleep(0.01)
             else:
-                self.fail("descendant survived cleanup after its process-group leader exited")
+                self.fail(
+                    "descendant survived cleanup after its process-group leader exited"
+                )
 
     def test_side_effect_requires_exact_content(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- prepare the 0.0.42 release
- improve shell completion setup and cloud-auth guidance
- finish the Open Interpreter CLI identity sweep
- document current model choices and Chat Completions compatibility
- add reusable Ollama/Qwen tool-call coverage
- make the standalone release builder select a compatible Python runtime

## Validation

- focused CLI, utility, and model-manager Rust suites
- release-script and Ollama harness tests
- Linux standalone build and installed-binary identity/help checks